### PR TITLE
Fix allowance return

### DIFF
--- a/src/components/bodhi/createTopic.js
+++ b/src/components/bodhi/createTopic.js
@@ -8,6 +8,7 @@ import { withRouter } from 'react-router-dom';
 
 import topicActions from '../../redux/topic/actions';
 import appActions from '../../redux/app/actions';
+import { numToBNHex } from '../../helpers/utility';
 
 const FormItem = Form.Item;
 const Web3Utils = require('web3-utils');
@@ -62,12 +63,15 @@ class CreateTopic extends React.Component {
           resultSettingEndBlock,
         } = values;
 
+        const bettingEndBlockHex = numToBNHex(bettingEndBlock);
+        const resultSettingEndBlockHex = numToBNHex(resultSettingEndBlock);
+
         this.props.onCreateTopic({
           resultSetterAddress,
           name,
           options: _.filter(options, (item) => !!item), // Filter out empty strings in options
-          bettingEndBlock,
-          resultSettingEndBlock,
+          bettingEndBlock: bettingEndBlockHex,
+          resultSettingEndBlock: resultSettingEndBlockHex,
           senderAddress: this.getCurrentSenderAddress(),
         });
       }

--- a/src/containers/oracle.js
+++ b/src/containers/oracle.js
@@ -13,12 +13,13 @@ import LayoutContentWrapper from '../components/utility/layoutWrapper';
 import IsoWidgetsWrapper from './Widgets/widgets-wrapper';
 import dashboardActions from '../redux/dashboard/actions';
 import topicActions from '../redux/topic/actions';
+import { decimalToBotoshiHex } from '../helpers/utility';
 
 const RadioGroup = Radio.Group;
 const QTUM = 'QTUM';
 const BOT = 'BOT';
 const DEFAULT_RADIO_VALUE = 0;
-const ORACLE_BOT_THRESHOLD = 10000000000; // Botoshi
+const ORACLE_BOT_THRESHOLD = 100;
 const ALLOWANCE_TIMER_INTERVAL = 10 * 1000;
 
 const OracleType = {
@@ -445,7 +446,7 @@ class OraclePage extends React.Component {
     const { onApprove, selectedWalletAddress } = this.props;
     const { oracle } = this.state;
 
-    onApprove(oracle.topicAddress, amount, selectedWalletAddress);
+    onApprove(oracle.topicAddress, decimalToBotoshiHex(amount), selectedWalletAddress);
 
     this.setState({
       approving: true,
@@ -473,7 +474,7 @@ class OraclePage extends React.Component {
     const { oracle, radioValue } = this.state;
     const selectedIndex = oracle.optionIdxs[radioValue - 1];
 
-    onVote(oracle.address, selectedIndex, amount, selectedWalletAddress);
+    onVote(oracle.address, selectedIndex, decimalToBotoshiHex(amount), selectedWalletAddress);
   }
 
   finalizeResult() {

--- a/src/containers/oracle.js
+++ b/src/containers/oracle.js
@@ -343,7 +343,6 @@ class OraclePage extends React.Component {
     }
 
     if (allowanceReturn) {
-      console.log(allowanceReturn);
       const parsedAllowance = parseInt(allowanceReturn.result.remaining, 16);
       this.onAllowanceReturn(parsedAllowance);
     }

--- a/src/containers/oracle.js
+++ b/src/containers/oracle.js
@@ -343,7 +343,8 @@ class OraclePage extends React.Component {
     }
 
     if (allowanceReturn) {
-      const parsedAllowance = parseInt(allowanceReturn.result.executionResult.output, 16);
+      console.log(allowanceReturn);
+      const parsedAllowance = parseInt(allowanceReturn.result.remaining, 16);
       this.onAllowanceReturn(parsedAllowance);
     }
   }

--- a/src/containers/oracle.js
+++ b/src/containers/oracle.js
@@ -63,7 +63,7 @@ class OraclePage extends React.Component {
     }
 
     return _.map(oracle.optionIdxs, (optIndex, index) => {
-      const optionAmount = oracle.amounts[index] || 0;
+      const optionAmount = oracle.amounts[optIndex] || 0;
 
       return {
         name: oracle.options[optIndex],

--- a/src/helpers/utility.js
+++ b/src/helpers/utility.js
@@ -3,6 +3,7 @@ import BN from 'bn.js';
 const fetch = require('node-fetch');
 const BOTOSHI_TO_BOT = 100000000; // Both qtum and bot's conversion rate is 10^8 : 1
 const BOT_MIN_VALUE = 0.01; // Both qtum and bot's conversion rate is 10^8 : 1
+const BOT_DECIMALS = 8;
 
 export function clearToken() {
   localStorage.removeItem('id_token');
@@ -165,7 +166,15 @@ export function convertBNHexStrToQtum(input) {
  * @return {String} The converted decimal to BigNumber in hex format.
  */
 export function decimalToBotoshiHex(decimalNum) {
+  // Converting to BigNumber drops the decimals so we need to store the decimals as a BN to add it back.
+  let decimalsBN;
+  if (decimalNum.toString().indexOf('.') !== -1) {
+    decimalsBN = new BN(decimalNum.toFixed(BOT_DECIMALS).toString().split('.')[1]);
+  } else {
+    decimalsBN = new BN(0);
+  }
+
   const bigNumber = new BN(decimalNum);
   const botoshiBN = new BN(BOTOSHI_TO_BOT);
-  return bigNumber.mul(botoshiBN).toJSON();
+  return bigNumber.mul(botoshiBN).add(decimalsBN).toJSON();
 }

--- a/src/helpers/utility.js
+++ b/src/helpers/utility.js
@@ -158,3 +158,14 @@ export function convertBNHexStrToQtum(input) {
 
   return result >= BOT_MIN_VALUE ? result : 0;
 }
+
+/**
+ * Convert ES6 Int to Botoshi (BigNumber format).
+ * @param  {Number} Number to convert to Botoshi in decimal format.
+ * @return {String} The converted decimal to BigNumber in hex format.
+ */
+export function decimalToBotoshiHex(decimalNum) {
+  const bigNumber = new BN(decimalNum);
+  const botoshiBN = new BN(BOTOSHI_TO_BOT);
+  return bigNumber.mul(botoshiBN).toJSON();
+}

--- a/src/helpers/utility.js
+++ b/src/helpers/utility.js
@@ -178,3 +178,12 @@ export function decimalToBotoshiHex(decimalNum) {
   const botoshiBN = new BN(BOTOSHI_TO_BOT);
   return bigNumber.mul(botoshiBN).add(decimalsBN).toJSON();
 }
+
+/**
+ * Convert ES6 Int to BigNumber hex string.
+ * @param  {Number} Number to convert (no decimals).
+ * @return {String} The converted number to BigNumber in hex format.
+ */
+export function numToBNHex(number) {
+  return new BN(number).toJSON();
+}


### PR DESCRIPTION
**Fixed**
1. `allowanceReturn` was being parsed incorrectly, breaking `setResult()` and `vote()`, fixed the parsing
2. `vote()` was being sent in as a decimal vs `botoshi`. I had to change the qweb3 to accept hex format for uint256 values like this. And now we are sending to API/qweb3 setResult() and vote() as a BigNumber hex string.
3. send block numbers as hex strings now because they are uint256 as well.

Note: all `uint256` should be handled the same - sent to API as a BigNumber hex string. otherwise we can get data loss.