### PR TITLE
Ui refresh block change

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "isomorphic-boilerplate",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -276,7 +276,7 @@
       "resolved": "https://registry.npmjs.org/apollo-cache/-/apollo-cache-1.0.2.tgz",
       "integrity": "sha512-VolOQhSlS9LNjAJP2QjEw0c8dDBZ47rqbeu/ygA3DabCdY/cTGOeybpBHmFePHA7ZzOE6+2EPxIhGmTRIZhS7A==",
       "requires": {
-        "apollo-utilities": "1.0.3"
+        "apollo-utilities": "1.0.8"
       }
     },
     "apollo-cache-inmemory": {
@@ -285,7 +285,7 @@
       "integrity": "sha512-0VsSZjutGchfC9Upzi+09BowxqhbE54rmATQvJVFqjOWcP6axMQm6zIsVL4Ky/cWf7E/dhXspQDiNnka1XJz7g==",
       "requires": {
         "apollo-cache": "1.0.2",
-        "apollo-utilities": "1.0.3",
+        "apollo-utilities": "1.0.8",
         "graphql-anywhere": "4.0.2"
       }
     },
@@ -299,7 +299,7 @@
         "apollo-cache": "1.0.2",
         "apollo-link": "1.0.5",
         "apollo-link-dedup": "1.0.3",
-        "apollo-utilities": "1.0.3",
+        "apollo-utilities": "1.0.8",
         "symbol-observable": "1.1.0",
         "zen-observable": "0.6.0"
       }
@@ -310,7 +310,7 @@
       "integrity": "sha512-JiGPOZhrg4ANK9A0TvfL7GGml14w82nTZayxN5ccLnQi0jh82ZNGl5S3085EjJGCAFZ4lMoBalkBMENr9m8xnA==",
       "requires": {
         "@types/zen-observable": "0.5.3",
-        "apollo-utilities": "1.0.3",
+        "apollo-utilities": "1.0.8",
         "zen-observable": "0.6.0"
       }
     },
@@ -330,10 +330,35 @@
         "apollo-link": "1.0.5"
       }
     },
+    "apollo-link-ws": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/apollo-link-ws/-/apollo-link-ws-1.0.5.tgz",
+      "integrity": "sha512-RcFCRK5YbhKAlaKwKDRrcU5bGnzY0AML919Ho3AS7LVK2Zb6fykYmJmZ28w79Pkke/w8Z94mB4Ml9tqK6ueSSw==",
+      "requires": {
+        "apollo-link": "1.1.0"
+      },
+      "dependencies": {
+        "apollo-link": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.1.0.tgz",
+          "integrity": "sha512-8SP3GtYSMpLa6KJaGfgr3NO/wWmB7xLWASQt3Agf08SljGNx3SOt99Yv5VtM8FPs62BoQmESX73IRmtrD1exdA==",
+          "requires": {
+            "@types/zen-observable": "0.5.3",
+            "apollo-utilities": "1.0.8",
+            "zen-observable": "0.7.1"
+          }
+        },
+        "zen-observable": {
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.7.1.tgz",
+          "integrity": "sha512-OI6VMSe0yeqaouIXtedC+F55Sr6r9ppS7+wTbSexkYdHbdt4ctTuPNXP/rwm7GTVI63YBc+EBT0b0tl7YnJLRg=="
+        }
+      }
+    },
     "apollo-utilities": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.0.3.tgz",
-      "integrity": "sha512-wNKf0GAXfvnmZFYVl1YIzZ6LDSUe+zo4SKd2kbzi7YquNZUuSwJnG1FfEphvfwRRTI2dnpcGZEq26I7uUBrWNw=="
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.0.8.tgz",
+      "integrity": "sha512-EvqRJCw5xy2gWeH37toUimbEkmUxronCosBNE4tOCJvZUMLLGB8CuTQ5RsBhKJm+rZ6kwGxV+2uszk14f/P/rA=="
     },
     "append-transform": {
       "version": "0.4.0",
@@ -1524,6 +1549,11 @@
       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
       "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
       "dev": true
+    },
+    "backo2": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
+      "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc="
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -5532,7 +5562,7 @@
       "resolved": "https://registry.npmjs.org/graphql-anywhere/-/graphql-anywhere-4.0.2.tgz",
       "integrity": "sha512-nCjKwOKZ52G1ObR1ct9rotuLKvOMun0h14SRwMvq37rh3uuTQBilXPk5xr9nM2yQhR0cUjikmDkM8uD4Msgoqg==",
       "requires": {
-        "apollo-utilities": "1.0.3"
+        "apollo-utilities": "1.0.8"
       }
     },
     "graphql-tag": {
@@ -7726,6 +7756,11 @@
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
       "dev": true
     },
+    "lodash.assign": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
+    },
     "lodash.assignin": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.assignin/-/lodash.assignin-4.2.0.tgz",
@@ -7809,11 +7844,21 @@
       "integrity": "sha1-SeKM1VkBNFjIFMVHnTxmOiG/qmw=",
       "dev": true
     },
+    "lodash.isobject": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
+      "integrity": "sha1-PI+41bW/S/kK4G4U8qUwpO2TXh0="
+    },
     "lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
       "dev": true
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
     },
     "lodash.keys": {
       "version": "3.1.2",
@@ -13414,6 +13459,28 @@
       "version": "3.4.5",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-3.4.5.tgz",
       "integrity": "sha512-xxfO3FlxEKcNL1gTX4Tb/tyDLOlUcWCQopceIoQe7sBsX81Na83PNba7DFqMqgb9Rn1VjHkSAWdS9uhL/NVo+Q=="
+    },
+    "subscriptions-transport-ws": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.9.5.tgz",
+      "integrity": "sha512-YFTdjCzSlDcY0UiagrA7dOt+OuvG/xQAvP1kuKVT5VgU0IQjGJste01MfIpwoH9DrD78Kbh/q0usOj4hoaITow==",
+      "requires": {
+        "backo2": "1.0.2",
+        "eventemitter3": "2.0.3",
+        "iterall": "1.1.3",
+        "lodash.assign": "4.2.0",
+        "lodash.isobject": "3.0.2",
+        "lodash.isstring": "4.0.1",
+        "symbol-observable": "1.1.0",
+        "ws": "3.3.3"
+      },
+      "dependencies": {
+        "eventemitter3": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.3.tgz",
+          "integrity": "sha1-teEHm1n7XhuidxwKmTvgYKWMmbo="
+        }
+      }
     },
     "supports-color": {
       "version": "4.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12403,6 +12403,15 @@
         "base16": "1.0.0"
       }
     },
+    "redux-graphql-subscriptions": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/redux-graphql-subscriptions/-/redux-graphql-subscriptions-0.0.9.tgz",
+      "integrity": "sha512-uomcxVhXMsZJzSzX0qym1ooRJYHEJVuyUDdJFi0vcPOxKqhqRxim01+CvkvCKgi75oBK/IrkGk963V/WfsNi7g==",
+      "requires": {
+        "graphql": "0.11.7",
+        "subscriptions-transport-ws": "0.9.5"
+      }
+    },
     "redux-mock-store": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/redux-mock-store/-/redux-mock-store-1.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "apollo-cache-inmemory": "^1.1.3",
     "apollo-client": "^2.1.0",
     "apollo-link-http": "^1.3.0",
+    "apollo-link-ws": "^1.0.5",
+    "apollo-utilities": "^1.0.8",
     "clone": "^2.1.1",
     "globalize": "^1.2.3",
     "graphql": "^0.11.7",
@@ -55,6 +57,7 @@
     "rheostat": "^2.1.1",
     "styled-components": "^2.2.1",
     "styled-theme": "^0.3.3",
+    "subscriptions-transport-ws": "^0.9.5",
     "web3-utils": "^1.0.0-beta.27",
     "yarn": "^1.3.2"
   },

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "redux-devtools": "^3.3.2",
     "redux-devtools-dock-monitor": "^1.1.1",
     "redux-devtools-log-monitor": "^1.2.0",
+    "redux-graphql-subscriptions": "0.0.9",
     "redux-saga": "^0.15.4",
     "redux-thunk": "^2.2.0",
     "rheostat": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "isomorphic-boilerplate",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "dependencies": {
     "antd": "^2.12.2",

--- a/src/components/bodhi/createTopic.js
+++ b/src/components/bodhi/createTopic.js
@@ -221,7 +221,7 @@ class CreateTopic extends React.Component {
   }
 
   renderBlockField(formItemLayout, id) {
-    const { syncInfo } = this.props;
+    const { chainBlockNum } = this.props;
     const {
       bettingStartBlock,
       bettingEndBlock,
@@ -229,7 +229,6 @@ class CreateTopic extends React.Component {
       resultSettingEndBlock,
     } = this.state;
     const blockNumDisabled = true;
-    const blockCount = syncInfo.chainBlockNum;
 
     let label;
     let extra;
@@ -249,7 +248,7 @@ class CreateTopic extends React.Component {
             },
           ],
         };
-        min = blockCount;
+        min = chainBlockNum;
         block = bettingStartBlock;
         break;
       }
@@ -269,7 +268,7 @@ class CreateTopic extends React.Component {
           ],
         };
         min = _.isNumber(this.props.form.getFieldValue(ID_BETTING_START_TIME)) ?
-          this.props.form.getFieldValue(ID_BETTING_START_TIME) + 1 : blockCount + 1;
+          this.props.form.getFieldValue(ID_BETTING_START_TIME) + 1 : chainBlockNum + 1;
         block = bettingEndBlock;
         break;
       }
@@ -289,7 +288,7 @@ class CreateTopic extends React.Component {
           ],
         };
         min = _.isNumber(this.props.form.getFieldValue(ID_BETTING_END_TIME)) ?
-          this.props.form.getFieldValue(ID_BETTING_END_TIME) : blockCount + 1;
+          this.props.form.getFieldValue(ID_BETTING_END_TIME) : chainBlockNum + 1;
         block = resultSettingStartBlock;
         break;
       }
@@ -309,7 +308,7 @@ class CreateTopic extends React.Component {
           ],
         };
         min = _.isNumber(this.props.form.getFieldValue(ID_RESULT_SETTING_START_TIME)) ?
-          this.props.form.getFieldValue(ID_RESULT_SETTING_START_TIME) + 1 : blockCount + 1;
+          this.props.form.getFieldValue(ID_RESULT_SETTING_START_TIME) + 1 : chainBlockNum + 1;
         block = resultSettingEndBlock;
         break;
       }
@@ -390,13 +389,12 @@ class CreateTopic extends React.Component {
 
   onDatePickerDateSelect(id, date) {
     const {
-      syncInfo,
+      chainBlockNum,
       averageBlockTime,
     } = this.props;
 
-    const blockCount = syncInfo.chainBlockNum;
     const localDate = date.local();
-    const block = calculateBlock(blockCount, localDate, averageBlockTime);
+    const block = calculateBlock(chainBlockNum, localDate, averageBlockTime);
 
     switch (id) {
       case ID_BETTING_START_TIME: {
@@ -561,7 +559,7 @@ CreateTopic.propTypes = {
   getInsightTotals: PropTypes.func,
   walletAddrs: PropTypes.array,
   walletAddrsIndex: PropTypes.number,
-  syncInfo: PropTypes.object,
+  chainBlockNum: PropTypes.number,
   averageBlockTime: PropTypes.number,
 };
 
@@ -572,7 +570,7 @@ CreateTopic.defaultProps = {
   getInsightTotals: undefined,
   walletAddrs: [],
   walletAddrsIndex: 0,
-  syncInfo: undefined,
+  chainBlockNum: undefined,
   averageBlockTime: defaults.averageBlockTime,
 };
 
@@ -580,7 +578,7 @@ const mapStateToProps = (state) => ({
   createReturn: state.Topic.get('create_return'),
   walletAddrs: state.App.get('walletAddrs'),
   walletAddrsIndex: state.App.get('walletAddrsIndex'),
-  syncInfo: state.App.get('syncInfo') && state.App.get('syncInfo').result,
+  chainBlockNum: state.App.get('chainBlockNum'),
   averageBlockTime: state.App.get('averageBlockTime'),
 });
 

--- a/src/config/app.js
+++ b/src/config/app.js
@@ -6,7 +6,7 @@ const BASE_INSIGHT_PROD = 'https://explorer.qtum.org/insight-api';
 
 module.exports = {
   endpoint: {
-    bodhiapi: HTTP_ROUTE,
+    api: HTTP_ROUTE,
     graphHttp: `${HTTP_ROUTE}/graphql`,
     graphWs: WS_ROUTE,
     insight: BASE_INSIGHT_DEV,

--- a/src/config/app.js
+++ b/src/config/app.js
@@ -1,11 +1,14 @@
-const BASE_URL = 'http://localhost:5555';
+const HOSTNAME = '127.0.0.1';
+const HTTP_ROUTE = `http://${HOSTNAME}:5555`;
+const WS_ROUTE = `ws://${HOSTNAME}:5555`;
 const BASE_INSIGHT_DEV = 'https://testnet.qtum.org/insight-api';
 const BASE_INSIGHT_PROD = 'https://explorer.qtum.org/insight-api';
 
 module.exports = {
   endpoint: {
-    bodhiapi: BASE_URL,
-    graphql: `${BASE_URL}/graphql`,
+    bodhiapi: HTTP_ROUTE,
+    graphHttp: `${HTTP_ROUTE}/graphql`,
+    graphWs: WS_ROUTE,
     insight: BASE_INSIGHT_DEV,
   },
   intervals: { // in MS

--- a/src/config/app.js
+++ b/src/config/app.js
@@ -8,7 +8,7 @@ module.exports = {
   endpoint: {
     api: HTTP_ROUTE,
     graphHttp: `${HTTP_ROUTE}/graphql`,
-    graphWs: WS_ROUTE,
+    graphWs: `${WS_ROUTE}/subscriptions`,
     insight: BASE_INSIGHT_DEV,
   },
   intervals: { // in MS

--- a/src/config/app.js
+++ b/src/config/app.js
@@ -12,8 +12,7 @@ module.exports = {
     insight: BASE_INSIGHT_DEV,
   },
   intervals: { // in MS
-    syncInfo: 10000,
-    listUnspent: 10000,
+    syncInfo: 20000,
   },
   defaults: {
     averageBlockTime: 142.01324503311258,

--- a/src/config/routes.js
+++ b/src/config/routes.js
@@ -1,6 +1,6 @@
 import { endpoint } from './app';
 
-const BODHI_API = endpoint.bodhiapi;
+const BODHI_API = endpoint.api;
 const INSIGHT_API = endpoint.insight;
 
 const Routes = {

--- a/src/containers/App/App.js
+++ b/src/containers/App/App.js
@@ -5,6 +5,9 @@ import { IntlProvider } from 'react-intl';
 import { Debounce } from 'react-throttle';
 import { WindowResizeListener } from 'react-window-resize-listener';
 import { ThemeProvider } from 'styled-components';
+import { ApolloProvider } from 'react-apollo';
+
+import graphClient from '../../network/graphClient';
 import authAction from '../../redux/auth/actions';
 import appActions from '../../redux/app/actions';
 import Topbar from '../Topbar/Topbar';
@@ -32,40 +35,42 @@ export class App extends React.PureComponent {
           messages={currentAppLocale.messages}
         >
           <ThemeProvider theme={themes[themeConfig.theme]}>
-            <AppHolder>
-              <Layout style={{ height: '100vh' }}>
-                <Debounce time="1000" handler="onResize">
-                  <WindowResizeListener
-                    onResize={(windowSize) =>
-                      this.props.toggleAll(
-                        windowSize.windowWidth,
-                        windowSize.windowHeight
-                      )}
-                  />
-                </Debounce>
-                <AppLoad />
-                <Topbar url={url} />
-                <Layout style={{ flexDirection: 'row', overflowX: 'hidden' }}>
-                  <Layout
-                    className="isoContentMainLayout"
-                    style={{
-                      height: '100vh',
-                    }}
-                  >
-                    <Content
-                      className="isomorphicContent"
+            <ApolloProvider client={graphClient}>
+              <AppHolder>
+                <Layout style={{ height: '100vh' }}>
+                  <Debounce time="1000" handler="onResize">
+                    <WindowResizeListener
+                      onResize={(windowSize) =>
+                        this.props.toggleAll(
+                          windowSize.windowWidth,
+                          windowSize.windowHeight
+                        )}
+                    />
+                  </Debounce>
+                  <AppLoad />
+                  <Topbar url={url} />
+                  <Layout style={{ flexDirection: 'row', overflowX: 'hidden' }}>
+                    <Layout
+                      className="isoContentMainLayout"
                       style={{
-                        flexShrink: '0',
-                        background: '#f9f9f9',
+                        height: '100vh',
                       }}
                     >
-                      <AppRouter url={url} />
-                    </Content>
+                      <Content
+                        className="isomorphicContent"
+                        style={{
+                          flexShrink: '0',
+                          background: '#f9f9f9',
+                        }}
+                      >
+                        <AppRouter url={url} />
+                      </Content>
+                    </Layout>
                   </Layout>
+                  <CornerClock />
                 </Layout>
-                <CornerClock />
-              </Layout>
-            </AppHolder>
+              </AppHolder>
+            </ApolloProvider>
           </ThemeProvider>
         </IntlProvider>
       </LocaleProvider>

--- a/src/containers/App/App.js
+++ b/src/containers/App/App.js
@@ -20,7 +20,7 @@ import AppHolder from './commonStyle';
 import AppLoad from '../appLoad';
 import './global.css';
 
-const { Content /* Footer */ } = Layout;
+const { Content } = Layout;
 const { logout } = authAction;
 const { toggleAll } = appActions;
 
@@ -30,10 +30,7 @@ export class App extends React.PureComponent {
     const currentAppLocale = AppLocale.en;
     return (
       <LocaleProvider locale={currentAppLocale.antd}>
-        <IntlProvider
-          locale={currentAppLocale.locale}
-          messages={currentAppLocale.messages}
-        >
+        <IntlProvider locale={currentAppLocale.locale} messages={currentAppLocale.messages}>
           <ThemeProvider theme={themes[themeConfig.theme]}>
             <ApolloProvider client={graphClient}>
               <AppHolder>

--- a/src/containers/App/App.js
+++ b/src/containers/App/App.js
@@ -61,15 +61,6 @@ export class App extends React.PureComponent {
                     >
                       <AppRouter url={url} />
                     </Content>
-                    {/* <Footer
-                                          style={{
-                                            background: '#ffffff',
-                                            textAlign: 'center',
-                                            borderTop: '1px solid #ededed',
-                                          }}
-                                        >
-                                          {siteConfig.footerText}
-                                        </Footer> */}
                   </Layout>
                 </Layout>
                 <CornerClock />

--- a/src/containers/CornerClock/CornerClock.js
+++ b/src/containers/CornerClock/CornerClock.js
@@ -28,10 +28,10 @@ class CornerClock extends React.PureComponent {
   }
 
   render() {
-    const { syncInfo } = this.props;
+    const { syncBlockNum, syncBlockTime } = this.props;
 
-    const blockNum = syncInfo && syncInfo.syncBlockNum ? syncInfo.syncBlockNum : '';
-    const blockTime = syncInfo && syncInfo.syncBlockTime ? getShortLocalDateTimeString(syncInfo.syncBlockTime) : '';
+    const blockNum = syncBlockNum;
+    const blockTime = syncBlockTime ? getShortLocalDateTimeString(syncBlockTime) : '';
 
     return (
       <Card className="corner-block-wrapper">
@@ -63,16 +63,19 @@ class CornerClock extends React.PureComponent {
 }
 
 CornerClock.propTypes = {
-  syncInfo: PropTypes.object,
+  syncBlockNum: PropTypes.number,
+  syncBlockTime: PropTypes.number,
 };
 
 CornerClock.defaultProps = {
-  syncInfo: undefined,
+  syncBlockNum: undefined,
+  syncBlockTime: undefined,
 };
 
 const mapStateToProps = (state) => ({
   ...state.App.toJS(),
-  syncInfo: state.App.get('syncInfo') && state.App.get('syncInfo').result,
+  syncBlockNum: state.App.get('syncBlockNum'),
+  syncBlockTime: state.App.get('syncBlockTime'),
 });
 
 export default connect(mapStateToProps)(CornerClock);

--- a/src/containers/Topbar/Topbar.js
+++ b/src/containers/Topbar/Topbar.js
@@ -107,23 +107,22 @@ class Topbar extends React.PureComponent {
   }
 
   componentWillMount() {
-    const { listUnspent } = this.props;
-
-    // Start listUnspent long polling
-    function pollListUnspent() {
-      listUnspent();
-      setTimeout(pollListUnspent, AppConfig.intervals.listUnspent);
-    }
-    pollListUnspent();
+    this.props.listUnspent();
   }
 
   componentWillReceiveProps(nextProps) {
-    const { getBotBalance } = this.props;
+    const { nextWalletAddrs, nextSyncBlockNum } = nextProps;
+    const { walletAddrs, syncBlockNum, listUnspent, getBotBalance } = this.props;
+
+    // Update page on new block
+    if (nextSyncBlockNum !== syncBlockNum) {
+      listUnspent();
+    }
 
     // Call API to retrieve BOT balance if BOTs does not exist or wallet addresses have changed
-    const botArray = _.filter(this.props.walletAddrs, (item) => !!item.bot);
+    const botArray = _.filter(walletAddrs, (item) => !!item.bot);
 
-    if (_.isEmpty(botArray) || !_.isEqual(this.props.walletAddrs, nextProps.walletAddrs)) {
+    if (_.isEmpty(botArray) || !_.isEqual(walletAddrs, nextWalletAddrs)) {
       _.each(nextProps.walletAddrs, (addressObj) => {
         const ownerAddress = addressObj.address;
         const senderAddress = addressObj.address;
@@ -277,6 +276,7 @@ Topbar.propTypes = {
   selectWalletAddress: PropTypes.func,
   listUnspent: PropTypes.func,
   getBotBalance: PropTypes.func,
+  syncBlockNum: PropTypes.number,
 };
 
 Topbar.defaultProps = {
@@ -286,12 +286,14 @@ Topbar.defaultProps = {
   selectWalletAddress: undefined,
   listUnspent: undefined,
   getBotBalance: undefined,
+  syncBlockNum: undefined,
 };
 
 const mapStateToProps = (state) => ({
   ...state.App.toJS(),
   walletAddrs: state.App.get('walletAddrs'),
   selectedWalletAddress: state.App.get('selected_wallet_address'),
+  syncBlockNum: state.App.get('syncBlockNum'),
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/src/containers/Topbar/Topbar.js
+++ b/src/containers/Topbar/Topbar.js
@@ -225,30 +225,6 @@ class Topbar extends React.PureComponent {
     );
   }
 
-<<<<<<< HEAD
-=======
-  renderBlockInfo() {
-    const { syncBlockNum, syncBlockTime } = this.props;
-
-    const blockNum = syncBlockNum;
-    const blockTime = syncBlockTime ? getShortLocalDateTimeString(syncBlockTime) : '';
-
-    return (
-      <div
-        className="block-count"
-        style={{ color: 'white', paddingTop: '16px', textAlign: 'right' }}
-      >
-        <div style={{ fontSize: '14px', lineHeight: 'normal' }}>
-          Current Block: {blockNum}
-        </div>
-        <div style={{ fontSize: '14px', lineHeight: 'normal', marginTop: '4px' }}>
-          {blockTime}
-        </div>
-      </div>
-    );
-  }
-
->>>>>>> Refactor sync info returns to separate state vars
   onAddressDropdownClick({ key, item }) {
     if (key === KEY_ADD_ADDRESS_BTN) {
       this.showModal();

--- a/src/containers/Topbar/Topbar.js
+++ b/src/containers/Topbar/Topbar.js
@@ -225,6 +225,30 @@ class Topbar extends React.PureComponent {
     );
   }
 
+<<<<<<< HEAD
+=======
+  renderBlockInfo() {
+    const { syncBlockNum, syncBlockTime } = this.props;
+
+    const blockNum = syncBlockNum;
+    const blockTime = syncBlockTime ? getShortLocalDateTimeString(syncBlockTime) : '';
+
+    return (
+      <div
+        className="block-count"
+        style={{ color: 'white', paddingTop: '16px', textAlign: 'right' }}
+      >
+        <div style={{ fontSize: '14px', lineHeight: 'normal' }}>
+          Current Block: {blockNum}
+        </div>
+        <div style={{ fontSize: '14px', lineHeight: 'normal', marginTop: '4px' }}>
+          {blockTime}
+        </div>
+      </div>
+    );
+  }
+
+>>>>>>> Refactor sync info returns to separate state vars
   onAddressDropdownClick({ key, item }) {
     if (key === KEY_ADD_ADDRESS_BTN) {
       this.showModal();

--- a/src/containers/Topbar/Topbar.js
+++ b/src/containers/Topbar/Topbar.js
@@ -107,27 +107,37 @@ class Topbar extends React.PureComponent {
   }
 
   componentWillMount() {
-    this.props.listUnspent();
+    const {
+      listUnspent,
+      getBotBalance,
+      walletAddrs,
+    } = this.props;
+
+    listUnspent();
+    if (!_.isEmpty(walletAddrs)) {
+      _.each(walletAddrs, (address) => {
+        getBotBalance(address.address, address.address);
+      });
+    }
   }
 
   componentWillReceiveProps(nextProps) {
-    const { nextWalletAddrs, nextSyncBlockNum } = nextProps;
-    const { walletAddrs, syncBlockNum, listUnspent, getBotBalance } = this.props;
+    const {
+      walletAddrs,
+      syncBlockNum,
+      listUnspent,
+      getBotBalance,
+    } = this.props;
 
     // Update page on new block
-    if (nextSyncBlockNum !== syncBlockNum) {
+    if (nextProps.syncBlockNum !== syncBlockNum) {
       listUnspent();
-    }
 
-    // Call API to retrieve BOT balance if BOTs does not exist or wallet addresses have changed
-    const botArray = _.filter(walletAddrs, (item) => !!item.bot);
-
-    if (_.isEmpty(botArray) || !_.isEqual(walletAddrs, nextWalletAddrs)) {
-      _.each(nextProps.walletAddrs, (addressObj) => {
-        const ownerAddress = addressObj.address;
-        const senderAddress = addressObj.address;
-        getBotBalance(ownerAddress, senderAddress);
-      });
+      if (nextProps.walletAddrs) {
+        _.each(nextProps.walletAddrs, (address) => {
+          getBotBalance(address.address, address.address);
+        });
+      }
     }
   }
 

--- a/src/containers/appLoad.js
+++ b/src/containers/appLoad.js
@@ -29,12 +29,13 @@ class AppLoad extends React.PureComponent {
   }
 
   componentWillReceiveProps(nextProps) {
-    const { syncInfo } = nextProps;
+    const {
+      chainBlockNum,
+      syncBlockNum,
+    } = nextProps;
 
     // Only update if both syncBlockNum or chainBlockNum are defined as number
-    if (syncInfo && _.isNumber(syncInfo.syncBlockNum) && _.isNumber(syncInfo.chainBlockNum)) {
-      const { syncBlockNum, chainBlockNum } = syncInfo;
-
+    if (_.isNumber(syncBlockNum) && _.isNumber(chainBlockNum)) {
       let newPercent = _.round((syncBlockNum / chainBlockNum) * 100);
 
       // Make new percent 100 if block gap is less than MIN_BLOCK_COUNT_GAP
@@ -85,21 +86,24 @@ class AppLoad extends React.PureComponent {
 }
 
 AppLoad.propTypes = {
-  syncInfo: PropTypes.object,
+  chainBlockNum: PropTypes.number,
+  syncBlockNum: PropTypes.number,
   getSyncInfo: PropTypes.func,
   updateSyncProgress: PropTypes.func,
   toggleSyncing: PropTypes.func,
 };
 
 AppLoad.defaultProps = {
-  syncInfo: undefined,
+  chainBlockNum: undefined,
+  syncBlockNum: undefined,
   getSyncInfo: undefined,
   updateSyncProgress: undefined,
   toggleSyncing: undefined,
 };
 
 const mapStateToProps = (state) => ({
-  syncInfo: state.App.get('syncInfo') && state.App.get('syncInfo').result,
+  chainBlockNum: state.App.get('chainBlockNum'),
+  syncBlockNum: state.App.get('syncBlockNum'),
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/src/containers/dashboard.js
+++ b/src/containers/dashboard.js
@@ -58,9 +58,12 @@ class Dashboard extends React.Component {
       sortBy,
       syncProgress,
       isSyncing,
+      syncBlockNum,
     } = nextProps;
 
-    if (tabIndex !== this.props.tabIndex || sortBy !== this.props.sortBy) {
+    if (tabIndex !== this.props.tabIndex
+      || sortBy !== this.props.sortBy
+      || syncBlockNum !== this.props.syncBlockNum) {
       this.executeGraphRequest(tabIndex, sortBy);
     }
 
@@ -134,15 +137,15 @@ class Dashboard extends React.Component {
 
   executeGraphRequest(tabIndex, sortBy) {
     const {
-      onGetTopics,
-      onGetOracles,
+      getTopics,
+      getOracles,
     } = this.props;
 
     const sortDirection = sortBy || SortBy.Ascending;
 
     switch (tabIndex) {
       case TAB_BET: {
-        onGetOracles(
+        getOracles(
           [
             { token: Token.Qtum, status: OracleStatus.Voting },
           ],
@@ -151,7 +154,7 @@ class Dashboard extends React.Component {
         break;
       }
       case TAB_SET: {
-        onGetOracles(
+        getOracles(
           [
             { token: Token.Qtum, status: OracleStatus.WaitResult },
             { token: Token.Qtum, status: OracleStatus.OpenResultSet },
@@ -161,7 +164,7 @@ class Dashboard extends React.Component {
         break;
       }
       case TAB_VOTE: {
-        onGetOracles(
+        getOracles(
           [
             { token: Token.Bot, status: OracleStatus.Voting },
           ],
@@ -170,7 +173,7 @@ class Dashboard extends React.Component {
         break;
       }
       case TAB_FINALIZE: {
-        onGetOracles(
+        getOracles(
           [
             { token: Token.Bot, status: OracleStatus.WaitResult },
           ],
@@ -179,7 +182,7 @@ class Dashboard extends React.Component {
         break;
       }
       case TAB_WITHDRAW: {
-        onGetTopics(
+        getTopics(
           [
             { status: OracleStatus.Withdraw },
           ],
@@ -423,37 +426,37 @@ class Dashboard extends React.Component {
 }
 
 Dashboard.propTypes = {
+  getTopics: PropTypes.func,
   getTopicsSuccess: PropTypes.oneOfType([
     PropTypes.array, // Result array
     PropTypes.string, // error message
     PropTypes.bool, // No result
   ]),
-  onGetTopics: PropTypes.func,
+  getOracles: PropTypes.func,
   getOraclesSuccess: PropTypes.oneOfType([
     PropTypes.array, // Result array
     PropTypes.string, // error message
     PropTypes.bool, // No result
   ]),
-  // getOraclesError: PropTypes.string,
-  onGetOracles: PropTypes.func,
   tabIndex: PropTypes.number,
   sortBy: PropTypes.string,
   toggleSyncing: PropTypes.func,
   syncProgress: PropTypes.number,
   isSyncing: PropTypes.bool,
+  syncBlockNum: PropTypes.number,
 };
 
 Dashboard.defaultProps = {
+  getTopics: undefined,
   getTopicsSuccess: [],
-  onGetTopics: undefined,
+  getOracles: undefined,
   getOraclesSuccess: [],
-  // getOraclesError: '',
-  onGetOracles: undefined,
   tabIndex: DEFAULT_TAB_INDEX,
   sortBy: undefined,
   toggleSyncing: undefined,
   syncProgress: undefined,
   isSyncing: false,
+  syncBlockNum: undefined,
 };
 
 const mapStateToProps = (state) => ({
@@ -465,15 +468,15 @@ const mapStateToProps = (state) => ({
   sortBy: state.Dashboard.get('sortBy'),
   syncProgress: state.App.get('syncProgress'),
   isSyncing: state.App.get('isSyncing'),
+  syncBlockNum: state.App.get('syncBlockNum'),
 });
 
 function mapDispatchToProps(dispatch) {
   return {
-    onGetTopics: (filters, orderBy) => dispatch(dashboardActions.getTopics(filters, orderBy)),
-    onGetOracles: (filters, orderBy) => dispatch(dashboardActions.getOracles(filters, orderBy)),
+    getTopics: (filters, orderBy) => dispatch(dashboardActions.getTopics(filters, orderBy)),
+    getOracles: (filters, orderBy) => dispatch(dashboardActions.getOracles(filters, orderBy)),
     toggleSyncing: (isSyncing) => dispatch(appActions.toggleSyncing(isSyncing)),
   };
 }
 
-// Wrap the component to inject dispatch and state into it
 export default connect(mapStateToProps, mapDispatchToProps)(Dashboard);

--- a/src/containers/oracle.js
+++ b/src/containers/oracle.js
@@ -391,7 +391,7 @@ class OraclePage extends React.Component {
    * Determine next action based on returned allowance result
    * 1. If allowance is zero, send approve request
    * 2. If allowance is positive but less than voteAmount, send approve(0) to reset allowance
-   * 3. If allowance is greather than or equal to voteAmount and not isApproved, 
+   * 3. If allowance is greather than or equal to voteAmount and not isApproved,
    *    do action and reset isApproving and isApproved
    * @param  {number} allowance value
    * @return {}

--- a/src/containers/oracle.js
+++ b/src/containers/oracle.js
@@ -88,14 +88,13 @@ class OraclePage extends React.Component {
     const {
       getOraclesSuccess,
       allowanceReturn,
-      syncInfo,
+      syncBlockTime,
       selectedWalletAddress,
     } = nextProps;
 
     const oracle = _.find(getOraclesSuccess, { address: this.state.address });
     const centralizedOracle = _.find(getOraclesSuccess, { token: Token.Qtum });
     const decentralizedOracles = _.orderBy(_.filter(getOraclesSuccess, { token: Token.Bot }), ['blockNum'], ['asc']);
-    const blockTime = syncInfo.syncBlockTime;
 
     if (oracle) {
       const { token, status } = oracle;
@@ -107,7 +106,7 @@ class OraclePage extends React.Component {
           name: 'BETTING',
           breadcrumbLabel: 'Betting',
           cardInfo: {
-            steps: CardInfoUtil.getSteps(blockTime, oracle),
+            steps: CardInfoUtil.getSteps(syncBlockTime, oracle),
             messages: [
             ],
           },
@@ -127,7 +126,7 @@ class OraclePage extends React.Component {
           name: 'SETTING',
           breadcrumbLabel: 'Setting',
           cardInfo: {
-            steps: CardInfoUtil.getSteps(blockTime, oracle),
+            steps: CardInfoUtil.getSteps(syncBlockTime, oracle),
             messages: [
               {
                 text: `Result setter ${oracle.resultSetterQAddress || ''}`,
@@ -160,7 +159,7 @@ class OraclePage extends React.Component {
         };
 
         // Add a message to CardInfo to warn that current block has passed set end block
-        if (blockTime > oracle.resultSetEndTime) {
+        if (syncBlockTime > oracle.resultSetEndTime) {
           config.cardInfo.messages.push({
             text: 'Current block time has passed the Result Setting End Time.',
             type: 'warn',
@@ -184,7 +183,7 @@ class OraclePage extends React.Component {
           name: 'VOTING',
           breadcrumbLabel: 'Voting',
           cardInfo: {
-            steps: CardInfoUtil.getSteps(blockTime, centralizedOracle, decentralizedOracles),
+            steps: CardInfoUtil.getSteps(syncBlockTime, centralizedOracle, decentralizedOracles),
             messages: [
               {
                 text: `Consensus Threshold ${oracle.consensusThreshold || ''}. This value indicates the amount of BOT 
@@ -213,7 +212,7 @@ class OraclePage extends React.Component {
           name: 'FINALIZING',
           breadcrumbLabel: 'Voting',
           cardInfo: {
-            steps: CardInfoUtil.getSteps(blockTime, centralizedOracle, decentralizedOracles),
+            steps: CardInfoUtil.getSteps(syncBlockTime, centralizedOracle, decentralizedOracles),
             messages: [
             ],
           },
@@ -225,7 +224,7 @@ class OraclePage extends React.Component {
           },
         };
 
-        if (blockTime > oracle.endTime) {
+        if (syncBlockTime > oracle.endTime) {
           config.cardInfo.messages.push({
             text: `Current block time has passed the Voting End Time. 
               The previous result needs to be finalized in order to withdraw.`,
@@ -540,7 +539,7 @@ OraclePage.propTypes = {
   clearAllowanceReturn: PropTypes.func,
   requestReturn: PropTypes.object,
   selectedWalletAddress: PropTypes.string,
-  syncInfo: PropTypes.object,
+  syncBlockTime: PropTypes.number,
 };
 
 OraclePage.defaultProps = {
@@ -560,7 +559,7 @@ OraclePage.defaultProps = {
   clearEditingToggled: undefined,
   clearAllowanceReturn: undefined,
   selectedWalletAddress: undefined,
-  syncInfo: undefined,
+  syncBlockTime: undefined,
 };
 
 const mapStateToProps = (state) => ({
@@ -570,7 +569,7 @@ const mapStateToProps = (state) => ({
   requestReturn: state.Topic.get('req_return'),
   allowanceReturn: state.Topic.get('allowance_return'),
   selectedWalletAddress: state.App.get('selected_wallet_address'),
-  syncInfo: state.App.get('syncInfo') && state.App.get('syncInfo').result,
+  syncBlockTime: state.App.get('syncBlockTime'),
 });
 
 function mapDispatchToProps(dispatch) {

--- a/src/containers/topic.js
+++ b/src/containers/topic.js
@@ -72,88 +72,6 @@ class TopicPage extends React.Component {
     this.props.clearEditingToggled();
   }
 
-  calculateWinnings() {
-    try {
-      const {
-        selectedWalletAddress,
-        onCalculateWinnings,
-      } = this.props;
-
-      onCalculateWinnings(this.state.address, selectedWalletAddress);
-    } catch (err) {
-      console.log(err.message);
-    }
-  }
-
-  /** Withdraw button on click handler passed down to CardFinished */
-  onWithdrawClicked() {
-    const senderAddress = this.getCurrentSenderAddress();
-    const contractAddress = this.state.topic.address;
-
-    this.props.onWithdraw(contractAddress, senderAddress);
-  }
-
-  /** Return selected address on Topbar as sender * */
-  getCurrentSenderAddress() {
-    const { walletAddrs, walletAddrsIndex } = this.props;
-    return walletAddrs[walletAddrsIndex].address;
-  }
-
-  /**
-   * Configure UI elements in this.state.config and set topic object in this.state
-   * @param  {object} topic object
-   * @return {}
-   */
-  pageConfiguration(topic) {
-    const { syncBlockTime } = this.props;
-
-    if (topic) {
-      let config;
-
-      // Only shows Topic which are in WITHDRAW state
-      if (topic.status === OracleStatus.Withdraw) {
-        const centralizedOracle = _.find(topic.oracles, (item) => item.token === Token.Qtum);
-        const decentralizedOracles = _.orderBy(_.filter(topic.oracles, (item) => item.token === Token.Bot), ['blockNum'], ['asc']);
-
-        config = {
-          name: 'COMPLETED',
-          breadcrumbLabel: 'Completed',
-          cardInfo: {
-            steps: CardInfoUtil.getSteps(
-              syncBlockTime,
-              centralizedOracle,
-              decentralizedOracles,
-              true,
-            ),
-            messages: [
-            ],
-          },
-          cardAction: {
-            skipToggle: true,
-            beforeToggle: {
-              btnText: 'Finalize',
-            },
-          },
-        };
-
-        // Add withdrawal amount
-        config.cardInfo.messages.push({
-          text: `You can withdraw ${(topic.botWinnings && topic.botWinnings.toFixed(2)) || 0} ${Token.Bot} 
-            & ${(topic.qtumWinnings && topic.qtumWinnings.toFixed(2)) || 0} ${Token.Qtum}.`,
-          type: 'default',
-        });
-
-        // Highlight current step using current field
-        config.cardInfo.steps.current = config.cardInfo.steps.value.length - 1;
-
-        this.setState({
-          topic,
-          config,
-        });
-      }
-    }
-  }
-
   render() {
     const { requestReturn } = this.props;
     const { topic, config } = this.state;
@@ -236,6 +154,92 @@ class TopicPage extends React.Component {
         </Row>
       </LayoutContentWrapper>
     );
+  }
+
+  calculateWinnings() {
+    try {
+      const {
+        selectedWalletAddress,
+        onCalculateWinnings,
+      } = this.props;
+
+      onCalculateWinnings(this.state.address, selectedWalletAddress);
+    } catch (err) {
+      console.log(err.message);
+    }
+  }
+
+  /** Withdraw button on click handler passed down to CardFinished */
+  onWithdrawClicked() {
+    const senderAddress = this.getCurrentSenderAddress();
+    const contractAddress = this.state.topic.address;
+
+    this.props.onWithdraw(contractAddress, senderAddress);
+  }
+
+  /** Return selected address on Topbar as sender * */
+  getCurrentSenderAddress() {
+    const { walletAddrs, walletAddrsIndex } = this.props;
+    return walletAddrs[walletAddrsIndex].address;
+  }
+
+  /**
+   * Configure UI elements in this.state.config and set topic object in this.state
+   * @param  {object} topic object
+   * @return {}
+   */
+  pageConfiguration(topic) {
+    const { syncBlockTime } = this.props;
+
+    if (topic) {
+      let config;
+
+      // Only shows Topic which are in WITHDRAW state
+      if (topic.status === OracleStatus.Withdraw) {
+        const centralizedOracle = _.find(topic.oracles, (item) => item.token === Token.Qtum);
+        const decentralizedOracles = _.orderBy(
+          _.filter(topic.oracles, (item) => item.token === Token.Bot),
+          ['blockNum'],
+          ['asc'],
+        );
+
+        config = {
+          name: 'COMPLETED',
+          breadcrumbLabel: 'Completed',
+          cardInfo: {
+            steps: CardInfoUtil.getSteps(
+              syncBlockTime,
+              centralizedOracle,
+              decentralizedOracles,
+              true,
+            ),
+            messages: [
+            ],
+          },
+          cardAction: {
+            skipToggle: true,
+            beforeToggle: {
+              btnText: 'Finalize',
+            },
+          },
+        };
+
+        // Add withdrawal amount
+        config.cardInfo.messages.push({
+          text: `You can withdraw ${(topic.botWinnings && topic.botWinnings.toFixed(2)) || 0} ${Token.Bot} 
+            & ${(topic.qtumWinnings && topic.qtumWinnings.toFixed(2)) || 0} ${Token.Qtum}.`,
+          type: 'default',
+        });
+
+        // Highlight current step using current field
+        config.cardInfo.steps.current = config.cardInfo.steps.value.length - 1;
+
+        this.setState({
+          topic,
+          config,
+        });
+      }
+    }
   }
 }
 

--- a/src/containers/topic.js
+++ b/src/containers/topic.js
@@ -105,6 +105,8 @@ class TopicPage extends React.Component {
    * @return {}
    */
   pageConfiguration(topic) {
+    const { syncBlockTime } = this.props;
+
     if (topic) {
       let config;
 
@@ -118,7 +120,7 @@ class TopicPage extends React.Component {
           breadcrumbLabel: 'Completed',
           cardInfo: {
             steps: CardInfoUtil.getSteps(
-              this.props.syncInfo.syncBlockTime,
+              syncBlockTime,
               centralizedOracle,
               decentralizedOracles,
               true,
@@ -246,7 +248,7 @@ TopicPage.propTypes = {
   ]),
   match: PropTypes.object.isRequired,
   requestReturn: PropTypes.object,
-  syncInfo: PropTypes.object,
+  syncBlockTime: PropTypes.number,
   walletAddrs: PropTypes.array,
   walletAddrsIndex: PropTypes.number,
   selectedWalletAddress: PropTypes.string,
@@ -262,7 +264,7 @@ TopicPage.defaultProps = {
   getTopicsSuccess: undefined,
   onGetTopics: undefined,
   requestReturn: undefined,
-  syncInfo: undefined,
+  syncBlockTime: undefined,
   walletAddrs: [],
   walletAddrsIndex: 0,
   selectedWalletAddress: undefined,
@@ -278,7 +280,7 @@ const mapStateToProps = (state) => ({
   requestReturn: state.Topic.get('req_return'),
   calculateBotWinningsReturn: state.Topic.get('calculate_bot_winnings_return'),
   calculateQtumWinningsReturn: state.Topic.get('calculate_qtum_winnings_return'),
-  syncInfo: state.App.get('syncInfo') && state.App.get('syncInfo').result,
+  syncBlockTime: state.App.get('syncBlockTime'),
   walletAddrs: state.App.get('walletAddrs'),
   walletAddrsIndex: state.App.get('walletAddrsIndex'),
   selectedWalletAddress: state.App.get('selected_wallet_address'),

--- a/src/network/graphClient.js
+++ b/src/network/graphClient.js
@@ -1,0 +1,10 @@
+import { ApolloClient } from 'apollo-client';
+import { HttpLink } from 'apollo-link-http';
+import { InMemoryCache } from 'apollo-cache-inmemory';
+
+import { endpoint } from '../config/app';
+
+const client = new ApolloClient({
+  link: new HttpLink({ uri: endpoint.graphql }),
+  cache: new InMemoryCache(),
+});

--- a/src/network/graphClient.js
+++ b/src/network/graphClient.js
@@ -1,11 +1,37 @@
 import { ApolloClient } from 'apollo-client';
 import { HttpLink } from 'apollo-link-http';
+import { WebSocketLink } from 'apollo-link-ws';
 import { InMemoryCache } from 'apollo-cache-inmemory';
+import { split } from 'apollo-link';
+import { getMainDefinition } from 'apollo-utilities';
 
 import { endpoint } from '../config/app';
 
+const httpLink = new HttpLink({
+  uri: endpoint.graphHttp,
+});
+
+const wsLink = new WebSocketLink({
+  uri: endpoint.graphWs,
+  options: {
+    reconnect: true,
+  },
+});
+
+// using the ability to split links, you can send data to each link
+// depending on what kind of operation is being sent
+const link = split(
+  // split based on operation type
+  ({ query }) => {
+    const { kind, operation } = getMainDefinition(query);
+    return kind === 'OperationDefinition' && operation === 'subscription';
+  },
+  wsLink,
+  httpLink,
+);
+
 const client = new ApolloClient({
-  link: new HttpLink({ uri: endpoint.graphql }),
+  link,
   cache: new InMemoryCache(),
 });
 

--- a/src/network/graphClient.js
+++ b/src/network/graphClient.js
@@ -8,3 +8,5 @@ const client = new ApolloClient({
   link: new HttpLink({ uri: endpoint.graphql }),
   cache: new InMemoryCache(),
 });
+
+export default client;

--- a/src/network/graphRequest.js
+++ b/src/network/graphRequest.js
@@ -1,17 +1,8 @@
 import _ from 'lodash';
 import gql from 'graphql-tag';
-import { ApolloClient } from 'apollo-client';
-import { HttpLink } from 'apollo-link-http';
-import { InMemoryCache } from 'apollo-cache-inmemory';
 
-import { endpoint } from '../config/app';
 import GraphParser from './graphParser';
 import { isValidEnum, getQueryFields } from './graphDataStruct';
-
-const client = new ApolloClient({
-  link: new HttpLink({ uri: endpoint.graphql }),
-  cache: new InMemoryCache(),
-});
 
 class GraphRequest {
   constructor(queryName) {

--- a/src/network/graphRequest.js
+++ b/src/network/graphRequest.js
@@ -135,3 +135,20 @@ export function queryAllOracles(filters, orderBy) {
 export function querySyncInfo() {
   return new GraphRequest('syncInfo').execute();
 }
+
+export function subscribeSyncInfo() {
+  const query = gql`
+    subscription onNewSyncInfo {
+      syncInfo {
+        ${getQueryFields('syncInfo')}
+      }
+    }
+  `;
+
+  client.subscribe({
+    query,
+    variables: {},
+  }).subscribe((response) => {
+    console.log(response);
+  });
+}

--- a/src/network/graphRequest.js
+++ b/src/network/graphRequest.js
@@ -135,20 +135,3 @@ export function queryAllOracles(filters, orderBy) {
 export function querySyncInfo() {
   return new GraphRequest('syncInfo').execute();
 }
-
-export function subscribeSyncInfo() {
-  const query = gql`
-    subscription onNewSyncInfo {
-      syncInfo {
-        ${getQueryFields('syncInfo')}
-      }
-    }
-  `;
-
-  client.subscribe({
-    query,
-    variables: {},
-  }).subscribe((response) => {
-    console.log(response);
-  });
-}

--- a/src/network/graphRequest.js
+++ b/src/network/graphRequest.js
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import gql from 'graphql-tag';
 
+import client from './graphClient';
 import GraphParser from './graphParser';
 import { isValidEnum, getQueryFields } from './graphDataStruct';
 

--- a/src/network/graphSubscription.js
+++ b/src/network/graphSubscription.js
@@ -1,21 +1,17 @@
 import gql from 'graphql-tag';
 
-import client from './graphClient';
 import { getQueryFields } from './graphDataStruct';
 
-export function subscribeSyncInfo() {
-  const query = gql`
-    subscription onNewSyncInfo {
-      syncInfo {
+export default subscriptions = {
+  ON_SYNC_INFO: gql`
+    subscription onSyncInfo {
+      OnSyncInfo {
         ${getQueryFields('syncInfo')}
       }
     }
-  `;
+  `,
+};
 
-  client.subscribe({
-    query,
-    variables: {},
-  }).subscribe((response) => {
-    console.log(response);
-  });
-}
+export const channels = {
+	ON_SYNC_INFO: 'OnSyncInfo',
+};

--- a/src/network/graphSubscription.js
+++ b/src/network/graphSubscription.js
@@ -2,7 +2,7 @@ import gql from 'graphql-tag';
 
 import { getQueryFields } from './graphDataStruct';
 
-export default subscriptions = {
+const subscriptions = {
   ON_SYNC_INFO: gql`
     subscription onSyncInfo {
       OnSyncInfo {
@@ -12,6 +12,7 @@ export default subscriptions = {
   `,
 };
 
+export default subscriptions;
 export const channels = {
-	ON_SYNC_INFO: 'OnSyncInfo',
+  ON_SYNC_INFO: 'OnSyncInfo',
 };

--- a/src/network/graphSubscription.js
+++ b/src/network/graphSubscription.js
@@ -1,0 +1,21 @@
+import gql from 'graphql-tag';
+
+import client from './graphClient';
+import { getQueryFields } from './graphDataStruct';
+
+export function subscribeSyncInfo() {
+  const query = gql`
+    subscription onNewSyncInfo {
+      syncInfo {
+        ${getQueryFields('syncInfo')}
+      }
+    }
+  `;
+
+  client.subscribe({
+    query,
+    variables: {},
+  }).subscribe((response) => {
+    console.log(response);
+  });
+}

--- a/src/network/routes.js
+++ b/src/network/routes.js
@@ -1,4 +1,4 @@
-import { endpoint } from './app';
+import { endpoint } from '../config/app';
 
 const BODHI_API = endpoint.api;
 const INSIGHT_API = endpoint.insight;

--- a/src/redux/app/actions.js
+++ b/src/redux/app/actions.js
@@ -53,7 +53,7 @@ const actions = {
   }),
 
   LIST_UNSPENT: 'LIST_UNSPENT',
-  LIST_UNSPENT_RESULT: 'LIST_UNSPENT_RESULT',
+  LIST_UNSPENT_RETURN: 'LIST_UNSPENT_RETURN',
   listUnspent: () => ({
     type: actions.LIST_UNSPENT,
   }),

--- a/src/redux/app/actions.js
+++ b/src/redux/app/actions.js
@@ -32,6 +32,12 @@ const actions = {
     value,
   }),
 
+  SUBSCRIBE_SYNC_INFO: 'SUBSCRIBE_SYNC_INFO',
+  SUBSCRIBE_SYNC_INFO_RETURN: 'SUBSCRIBE_SYNC_INFO_RETURN',
+  subscribeSyncInfo: () => ({
+    type: actions.SUBSCRIBE_SYNC_INFO,
+  }),
+
   LIST_UNSPENT: 'LIST_UNSPENT',
   LIST_UNSPENT_RESULT: 'LIST_UNSPENT_RESULT',
   listUnspent: () => ({

--- a/src/redux/app/actions.js
+++ b/src/redux/app/actions.js
@@ -1,3 +1,7 @@
+import { subscribe, unsubscribe } from 'redux-graphql-subscriptions';
+
+import subscriptions, { channels } from '../../network/graphSubscription';
+
 export function getView(width) {
   let newView = 'MobileView';
   if (width > 1220) {
@@ -32,14 +36,24 @@ const actions = {
     value,
   }),
 
-  SUBSCRIBE_SYNC_INFO: 'SUBSCRIBE_SYNC_INFO',
   SUBSCRIBE_SYNC_INFO_RETURN: 'SUBSCRIBE_SYNC_INFO_RETURN',
-  subscribeSyncInfo: () => ({
-    type: actions.SUBSCRIBE_SYNC_INFO,
+  subscribeSyncInfo: () => subscribe({
+    query: subscriptions.ON_SYNC_INFO,
+    variables: {
+      channel: channels.ON_SYNC_INFO,
+    },
+    success: (result) => ({
+      type: actions.SUBSCRIBE_SYNC_INFO_RETURN,
+      value: { result },
+    }),
+    error: (error) => ({
+      type: actions.SUBSCRIBE_SYNC_INFO_RETURN,
+      value: error.message,
+    }),
   }),
 
   LIST_UNSPENT: 'LIST_UNSPENT',
-  LIST_UNSPENT_RESULT: 'LIST_UNSPENT_RESULT',
+  LIST_UNSPENT_RESULT: 'LIST_UNStPENT_RESULT',
   listUnspent: () => ({
     type: actions.LIST_UNSPENT,
   }),

--- a/src/redux/app/actions.js
+++ b/src/redux/app/actions.js
@@ -53,7 +53,7 @@ const actions = {
   }),
 
   LIST_UNSPENT: 'LIST_UNSPENT',
-  LIST_UNSPENT_RESULT: 'LIST_UNStPENT_RESULT',
+  LIST_UNSPENT_RESULT: 'LIST_UNSPENT_RESULT',
   listUnspent: () => ({
     type: actions.LIST_UNSPENT,
   }),

--- a/src/redux/app/reducer.js
+++ b/src/redux/app/reducer.js
@@ -116,8 +116,9 @@ export default function appReducer(state = initState, action) {
       break;
 
     case actions.GET_SYNC_INFO_RETURN:
-      return state.set('syncBlockNum', action.value.result.syncBlockNum)
-        .state.set('syncBlockTime', action.value.result.syncBlockTime);
+      return state.set('chainBlockNum', action.value.result.chainBlockNum)
+        .set('syncBlockNum', action.value.result.syncBlockNum)
+        .set('syncBlockTime', action.value.result.syncBlockTime);
 
     case actions.UPDATE_SYNC_PROGRESS: {
       return state.set('syncProgress', action.percentage);

--- a/src/redux/app/reducer.js
+++ b/src/redux/app/reducer.js
@@ -39,7 +39,7 @@ export default function appReducer(state = initState, action) {
       break;
     }
 
-    case actions.LIST_UNSPENT_RESULT: {
+    case actions.LIST_UNSPENT_RETURN: {
       let result = [];
       let newState = state;
       let combinedAddresses = [];
@@ -87,7 +87,6 @@ export default function appReducer(state = initState, action) {
       return newState.set('walletAddrs', existingAddresses);
     }
 
-    /** Bot Balance Return - update walletAddrs with returned BOT value * */
     case actions.GET_BOT_BALANCE_RETURN: {
       const walletAddrs = state.get('walletAddrs');
 

--- a/src/redux/app/reducer.js
+++ b/src/redux/app/reducer.js
@@ -116,7 +116,8 @@ export default function appReducer(state = initState, action) {
       break;
 
     case actions.GET_SYNC_INFO_RETURN:
-      return state.set('syncInfo', action.value);
+      return state.set('syncBlockNum', action.value.result.syncBlockNum)
+        .state.set('syncBlockTime', action.value.result.syncBlockTime);
 
     case actions.UPDATE_SYNC_PROGRESS: {
       return state.set('syncProgress', action.percentage);

--- a/src/redux/app/saga.js
+++ b/src/redux/app/saga.js
@@ -1,12 +1,10 @@
 import _ from 'lodash';
 import { all, takeEvery, put, fork, call } from 'redux-saga/effects';
 import fetch from 'node-fetch';
-import { subscribe, unsubscribe } from 'redux-graphql-subscriptions';
 
 import actions from './actions';
 import { request } from '../../network/httpRequest';
 import { querySyncInfo } from '../../network/graphRequest';
-import subscriptions, { channels } from '../../network/graphSubscription';
 import { convertBNHexStrToQtum } from '../../helpers/utility';
 import Routes from '../../network/routes';
 
@@ -91,29 +89,6 @@ export function* getBotBalanceRequestHandler() {
   });
 }
 
-export function* subscribeSyncInfo() {
-  yield takeEvery(actions.SUBSCRIBE_SYNC_INFO, function* subscribeSyncInfoRequest(action) {
-    subscribe({ 
-      query: subscriptions.ON_SYNC_INFO,
-      variables: {
-        channel: channels.ON_SYNC_INFO,
-      },
-      success: (result) => {
-        yield put({
-          type: actions.SUBSCRIBE_SYNC_INFO_RETURN,
-          value: { result },
-        });
-      },
-      error: (err) => {
-        yield put({
-          type: actions.SUBSCRIBE_SYNC_INFO_RETURN,
-          value: error.message,
-        });
-      },
-    );
-  });
-}
-
 export function* getSyncInfoRequestHandler() {
   yield takeEvery(actions.GET_SYNC_INFO, function* getSyncInfoRequest(action) {
     try {
@@ -155,7 +130,6 @@ export default function* topicSaga() {
   yield all([
     fork(listUnspentRequestHandler),
     fork(getBotBalanceRequestHandler),
-    fork(subscribeSyncInfo),
     fork(getSyncInfoRequestHandler),
     fork(getInsightTotalsRequestHandler),
   ]);

--- a/src/redux/app/saga.js
+++ b/src/redux/app/saga.js
@@ -1,10 +1,12 @@
 import _ from 'lodash';
 import { all, takeEvery, put, fork, call } from 'redux-saga/effects';
 import fetch from 'node-fetch';
+import { subscribe, unsubscribe } from 'redux-graphql-subscriptions';
 
 import actions from './actions';
 import { request } from '../../network/httpRequest';
 import { querySyncInfo } from '../../network/graphRequest';
+import subscriptions, { channels } from '../../network/graphSubscription';
 import { convertBNHexStrToQtum } from '../../helpers/utility';
 import Routes from '../../network/routes';
 
@@ -89,6 +91,29 @@ export function* getBotBalanceRequestHandler() {
   });
 }
 
+export function* subscribeSyncInfo() {
+  yield takeEvery(actions.SUBSCRIBE_SYNC_INFO, function* subscribeSyncInfoRequest(action) {
+    subscribe({ 
+      query: subscriptions.ON_SYNC_INFO,
+      variables: {
+        channel: channels.ON_SYNC_INFO,
+      },
+      success: (result) => {
+        yield put({
+          type: actions.SUBSCRIBE_SYNC_INFO_RETURN,
+          value: { result },
+        });
+      },
+      error: (err) => {
+        yield put({
+          type: actions.SUBSCRIBE_SYNC_INFO_RETURN,
+          value: error.message,
+        });
+      },
+    );
+  });
+}
+
 export function* getSyncInfoRequestHandler() {
   yield takeEvery(actions.GET_SYNC_INFO, function* getSyncInfoRequest(action) {
     try {
@@ -130,6 +155,7 @@ export default function* topicSaga() {
   yield all([
     fork(listUnspentRequestHandler),
     fork(getBotBalanceRequestHandler),
+    fork(subscribeSyncInfo),
     fork(getSyncInfoRequestHandler),
     fork(getInsightTotalsRequestHandler),
   ]);

--- a/src/redux/app/saga.js
+++ b/src/redux/app/saga.js
@@ -16,8 +16,9 @@ export function* listUnspentRequestHandler() {
       const result = yield call(request, Routes.listUnspent);
 
       if (_.isEmpty(result)) {
-        // If listunspent return is empty meaning one has no balance in his addresses we will get default qtumd account's address
-        // This is likely to be the case when bodhi-app is first installed
+        // If listunspent return is empty meaning one has no balance in his addresses
+        // we will get default qtumd account's address
+        // This is likely to be the case when first installed
         const options = {
           method: 'POST',
           body: JSON.stringify({
@@ -29,7 +30,7 @@ export function* listUnspentRequestHandler() {
         const defaultAddress = yield call(request, Routes.getAccountAddress, options);
 
         yield put({
-          type: actions.LIST_UNSPENT_RESULT,
+          type: actions.LIST_UNSPENT_RETURN,
           value: {
             result: [{
               address: defaultAddress,
@@ -40,13 +41,13 @@ export function* listUnspentRequestHandler() {
       } else {
         // If listunspent returns with a non-empty list
         yield put({
-          type: actions.LIST_UNSPENT_RESULT,
+          type: actions.LIST_UNSPENT_RETURN,
           value: { result },
         });
       }
     } catch (error) {
       yield put({
-        type: actions.LIST_UNSPENT_RESULT,
+        type: actions.LIST_UNSPENT_RETURN,
         value: { error: error.message ? error.message : '' },
       });
     }
@@ -71,7 +72,8 @@ export function* getBotBalanceRequestHandler() {
       };
 
       const result = yield call(request, Routes.botBalance, options);
-      const botValue = result && result.balance ? convertBNHexStrToQtum(result.balance) : 0; // Convert BN hex string from request to BOT number
+      // Convert BN hex string from request to BOT number
+      const botValue = result && result.balance ? convertBNHexStrToQtum(result.balance) : 0;
 
       yield put({
         type: actions.GET_BOT_BALANCE_RETURN,

--- a/src/redux/app/saga.js
+++ b/src/redux/app/saga.js
@@ -6,7 +6,7 @@ import actions from './actions';
 import { request } from '../../network/httpRequest';
 import { querySyncInfo } from '../../network/graphRequest';
 import { convertBNHexStrToQtum } from '../../helpers/utility';
-import Routes from '../../config/routes';
+import Routes from '../../network/routes';
 
 const DEFAULT_QTUMD_ACCOUNTNAME = '';
 

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -3,7 +3,7 @@ import createHistory from 'history/createBrowserHistory';
 import { routerReducer, routerMiddleware } from 'react-router-redux';
 import thunk from 'redux-thunk';
 import createSagaMiddleware from 'redux-saga';
-import createGraphQLSubscriptionsMiddleware from 'redux-graphql-subscriptions'
+import createGraphQLSubscriptionsMiddleware from 'redux-graphql-subscriptions';
 
 import reducers from './reducers';
 import rootSaga from './sagas';

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -3,13 +3,17 @@ import createHistory from 'history/createBrowserHistory';
 import { routerReducer, routerMiddleware } from 'react-router-redux';
 import thunk from 'redux-thunk';
 import createSagaMiddleware from 'redux-saga';
+import createGraphQLSubscriptionsMiddleware from 'redux-graphql-subscriptions'
+
 import reducers from './reducers';
 import rootSaga from './sagas';
+import { endpoint } from '../config/app';
 
 const history = createHistory();
 const sagaMiddleware = createSagaMiddleware();
 const routeMiddleware = routerMiddleware(history);
-const middlewares = [thunk, sagaMiddleware, routeMiddleware];
+const graphSubsMiddleware = createGraphQLSubscriptionsMiddleware(endpoint.graphWs);
+const middlewares = [thunk, sagaMiddleware, routeMiddleware, graphSubsMiddleware];
 
 const store = createStore(
   combineReducers({

--- a/src/redux/topic/saga.js
+++ b/src/redux/topic/saga.js
@@ -3,7 +3,7 @@ import actions from './actions';
 
 import { request } from '../../network/httpRequest';
 import { convertBNHexStrToQtum } from '../../helpers/utility';
-import Routes from '../../config/routes';
+import Routes from '../../network/routes';
 
 export function* betRequestHandler() {
   yield takeEvery(actions.BET, function* onBetRequest(action) {


### PR DESCRIPTION
Using the constant polling logic to get the new block, I added the logic to update all parts of the app depending on which page the user is on.

Next step will be for converting to GraphQL subscription to get new `syncInfo`. 

But this updating logic should be included for tomorrow's release.

- Separated `syncBlockNum`, `syncBlockTime`, and `chainBlockNum` as separate items from syncInfo request. This allows individual components to use what they need.
- Update current page and qtum/bot balance when new block comes in
- Added the logic to be ready to change over to GraphQL subscription, but didn't enable it yet
