### PR TITLE
Disable reload when clicking transaction dialog ok

### DIFF
--- a/src/components/TransactionSentDialog/index.js
+++ b/src/components/TransactionSentDialog/index.js
@@ -67,7 +67,7 @@ class TransactionSentDialog extends React.PureComponent {
           </DialogContentText>
         </DialogContent>
         <DialogActions>
-          <Button onClick={this.handleAlertClose} color="primary">
+          <Button color="primary">
             OK
           </Button>
         </DialogActions>
@@ -91,10 +91,6 @@ class TransactionSentDialog extends React.PureComponent {
       bodyPrimary: txReturn.error,
       bodySecondary: '',
     };
-  }
-
-  handleAlertClose() {
-    window.location.reload();
   }
 }
 

--- a/src/components/TransactionSentDialog/index.js
+++ b/src/components/TransactionSentDialog/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 import Typography from 'material-ui/Typography';
 import Button from 'material-ui/Button';
 import Dialog, {
@@ -12,6 +13,7 @@ import { withStyles } from 'material-ui/styles';
 import { injectIntl, intlShape, defineMessages } from 'react-intl';
 
 import styles from './styles';
+import graphqlActions from '../../redux/Graphql/actions';
 
 const messages = defineMessages({
   successMsg: {
@@ -30,6 +32,10 @@ const messages = defineMessages({
     id: 'str.transactionId',
     defaultMessage: 'Transaction ID',
   },
+  ok: {
+    id: 'str.ok',
+    defaultMessage: 'OK',
+  },
 });
 
 class TransactionSentDialog extends React.PureComponent {
@@ -38,10 +44,11 @@ class TransactionSentDialog extends React.PureComponent {
 
     this.getSuccessText = this.getSuccessText.bind(this);
     this.getErrorText = this.getErrorText.bind(this);
+    this.onOkClicked = this.onOkClicked.bind(this);
   }
 
   render() {
-    const { classes, txReturn } = this.props;
+    const { intl, classes, txReturn } = this.props;
 
     let contentText;
     if (txReturn) {
@@ -67,8 +74,8 @@ class TransactionSentDialog extends React.PureComponent {
           </DialogContentText>
         </DialogContent>
         <DialogActions>
-          <Button color="primary">
-            OK
+          <Button color="primary" onClick={this.onOkClicked}>
+            {intl.formatMessage(messages.ok)}
           </Button>
         </DialogActions>
       </Dialog>
@@ -92,11 +99,16 @@ class TransactionSentDialog extends React.PureComponent {
       bodySecondary: '',
     };
   }
+
+  onOkClicked() {
+    this.props.clearTxReturn();
+  }
 }
 
 TransactionSentDialog.propTypes = {
   classes: PropTypes.object.isRequired,
   txReturn: PropTypes.object,
+  clearTxReturn: PropTypes.func.isRequired,
   // eslint-disable-next-line react/no-typos
   intl: intlShape.isRequired,
 };
@@ -105,4 +117,13 @@ TransactionSentDialog.defaultProps = {
   txReturn: undefined,
 };
 
-export default injectIntl(withStyles(styles, { withTheme: true })(TransactionSentDialog));
+const mapStateToProps = (state) => ({
+});
+
+function mapDispatchToProps(dispatch) {
+  return {
+    clearTxReturn: () => dispatch(graphqlActions.clearTxReturn()),
+  };
+}
+
+export default injectIntl(connect(mapStateToProps, mapDispatchToProps)(withStyles(styles, { withTheme: true })(TransactionSentDialog)));

--- a/src/languageProvider/locales/en_US.json
+++ b/src/languageProvider/locales/en_US.json
@@ -90,6 +90,7 @@
   "str.end": "Ended",
   "str.fee": "Fee",
   "str.from": "From",
+  "str.ok": "OK",
   "str.outcome": "OUTCOMES",
   "str.qtum": "QTUM",
   "str.raise": "Raised",

--- a/src/scenes/CreateTopic/components/createTopic.js
+++ b/src/scenes/CreateTopic/components/createTopic.js
@@ -1,19 +1,21 @@
 /* eslint react/prop-types: 0 */ // --> OFF
 
-import _ from 'lodash';
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { Row, Col, Alert, Button, Form, Input, message, InputNumber, DatePicker, Icon } from 'antd';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
+import { FormattedMessage, injectIntl, intlShape, defineMessages } from 'react-intl';
+import _ from 'lodash';
 import moment from 'moment';
 import Web3Utils from 'web3-utils';
-import { FormattedMessage, injectIntl, intlShape, defineMessages } from 'react-intl';
 
 import graphqlActions from '../../../redux/Graphql/actions';
 import stateActions from '../../../redux/State/actions';
 import appActions from '../../../redux/App/actions';
 import { calculateBlock } from '../../../helpers/utility';
 import { defaults } from '../../../config/app';
+import TransactionSentDialog from '../../../components/TransactionSentDialog/index';
 
 const FormItem = Form.Item;
 
@@ -114,7 +116,6 @@ class CreateTopic extends React.Component {
     };
 
     this.getCurrentSenderAddress = this.getCurrentSenderAddress.bind(this);
-    this.renderAlertBox = this.renderAlertBox.bind(this);
     this.renderBlockField = this.renderBlockField.bind(this);
     this.renderResultsFields = this.renderResultsFields.bind(this);
     this.onDatePickerDateSelect = this.onDatePickerDateSelect.bind(this);
@@ -127,6 +128,7 @@ class CreateTopic extends React.Component {
     this.validateResultLength = this.validateResultLength.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
     this.onCancel = this.onCancel.bind(this);
+    this.navigateToDashboard = this.navigateToDashboard.bind(this);
   }
 
   componentWillMount() {
@@ -135,6 +137,16 @@ class CreateTopic extends React.Component {
 
   componentWillUnmount() {
     this.props.clearTxReturn();
+  }
+
+  componentWillReceiveProps(nextProps) {
+    const {
+      txReturn,
+    } = this.props;
+
+    if (txReturn && !nextProps.txReturn) {
+      this.navigateToDashboard();
+    }
   }
 
   render() {
@@ -169,6 +181,7 @@ class CreateTopic extends React.Component {
     if (_.isUndefined(keys)) {
       keys = ['0', '1'];
     }
+
     const required = true;
     return (
       <div className="create-topic-container">
@@ -238,7 +251,6 @@ class CreateTopic extends React.Component {
           </FormItem>
 
           <FormItem {...tailFormItemLayout} className="submit-controller">
-            {this.renderAlertBox(txReturn)}
             <Button
               type="primary"
               htmlType="submit"
@@ -256,6 +268,7 @@ class CreateTopic extends React.Component {
             </Button>
           </FormItem>
         </Form>
+        <TransactionSentDialog txReturn={txReturn} />
       </div>
     );
   }
@@ -269,34 +282,6 @@ class CreateTopic extends React.Component {
       return walletAddrs[walletAddrsIndex].address;
     }
     return '';
-  }
-
-  renderAlertBox(txReturn) {
-    let alertElement;
-    if (txReturn) {
-      if (txReturn.txid) {
-        alertElement =
-            (<Alert
-              message="Success!"
-              description={`${this.props.intl.formatMessage(messages.alertSuc)}
-                https://testnet.qtum.org/tx/${txReturn.txid}`}
-              type="success"
-              closable={false}
-            />);
-      } else if (txReturn.error) {
-        alertElement = (<Alert
-          message={this.props.intl.formatMessage(messages.alertFail)}
-          description={txReturn.error}
-          type="error"
-          closable={false}
-        />);
-      }
-    }
-    return (
-      <div className="alert-container">
-        {alertElement}
-      </div>
-    );
   }
 
   renderBlockField(formItemLayout, id) {
@@ -624,7 +609,10 @@ class CreateTopic extends React.Component {
 
   onCancel(evt) {
     evt.preventDefault();
+    this.navigateToDashboard();
+  }
 
+  navigateToDashboard() {
     this.props.history.push('/');
   }
 }

--- a/src/scenes/Oracle/index.js
+++ b/src/scenes/Oracle/index.js
@@ -73,10 +73,11 @@ class OraclePage extends React.Component {
       getOraclesReturn,
       getTransactionsReturn,
       syncBlockTime,
+      txReturn,
     } = nextProps;
 
     // Update page on new block
-    if (syncBlockTime !== this.props.syncBlockTime) {
+    if (syncBlockTime !== this.props.syncBlockTime || (this.props.txReturn && !txReturn)) {
       this.executeOracleAndTxsRequest();
     }
 

--- a/src/scenes/Topic/index.js
+++ b/src/scenes/Topic/index.js
@@ -49,10 +49,11 @@ class TopicPage extends React.Component {
       qtumWinnings,
       syncBlockTime,
       selectedWalletAddress,
+      txReturn,
     } = nextProps;
 
     // Update page on new block
-    if (syncBlockTime !== this.props.syncBlockTime) {
+    if (syncBlockTime !== this.props.syncBlockTime || (this.props.txReturn && !txReturn)) {
       this.executeTopicsRequest();
     }
 

--- a/src/scenes/Wallet/components/History/index.jsx
+++ b/src/scenes/Wallet/components/History/index.jsx
@@ -25,15 +25,24 @@ class WalletHistory extends React.Component {
       orderBy: 'time',
     };
 
+    this.getTransactions = this.getTransactions.bind(this);
     this.getTableHeader = this.getTableHeader.bind(this);
     this.createSortHandler = this.createSortHandler.bind(this);
     this.handleSorting = this.handleSorting.bind(this);
   }
 
   componentWillMount() {
-    this.props.getTransactions([
-      { type: TransactionType.Transfer },
-    ]);
+    this.getTransactions();
+  }
+
+  componentWillReceiveProps(nextProps) {
+    const {
+      txReturn,
+    } = this.props;
+
+    if (txReturn && !nextProps.txReturn) {
+      this.getTransactions();
+    }
   }
 
   render() {
@@ -52,6 +61,12 @@ class WalletHistory extends React.Component {
         </Grid>
       </Paper>
     );
+  }
+
+  getTransactions() {
+    this.props.getTransactions([
+      { type: TransactionType.Transfer },
+    ]);
   }
 
   getTableHeader() {
@@ -192,14 +207,17 @@ WalletHistory.propTypes = {
   classes: PropTypes.object.isRequired,
   getTransactions: PropTypes.func.isRequired,
   getTransactionsReturn: PropTypes.array,
+  txReturn: PropTypes.object,
 };
 
 WalletHistory.defaultProps = {
   getTransactionsReturn: [],
+  txReturn: undefined,
 };
 
 const mapStateToProps = (state) => ({
   getTransactionsReturn: state.Graphql.get('getTransactionsReturn'),
+  txReturn: state.Graphql.get('txReturn'),
 });
 
 function mapDispatchToProps(dispatch) {


### PR DESCRIPTION
Instead of reloading the window after pressing the OK button in `TransactionSentDialog`, I added logic to refresh all the pages where txs take place.