### PR TITLE
Refactor QTUM/BOT balance fetching logic

### DIFF
--- a/src/components/NavBar/index.js
+++ b/src/components/NavBar/index.js
@@ -111,13 +111,12 @@ class NavBar extends React.PureComponent {
 
 NavBar.propTypes = {
   classes: PropTypes.object.isRequired,
-  walletAddresses: PropTypes.array,
+  walletAddresses: PropTypes.array.isRequired,
   actionableItemCount: PropTypes.number,
   langHandler: PropTypes.func,
 };
 
 NavBar.defaultProps = {
-  walletAddresses: [],
   actionableItemCount: undefined,
   langHandler: undefined,
 };

--- a/src/components/NavBar/index.js
+++ b/src/components/NavBar/index.js
@@ -25,7 +25,7 @@ class NavBar extends React.PureComponent {
   render() {
     const {
       classes,
-      walletAddrs,
+      walletAddresses,
       actionableItemCount,
     } = this.props;
 
@@ -84,12 +84,12 @@ class NavBar extends React.PureComponent {
 
   getTotalQTUM() {
     const {
-      walletAddrs,
+      walletAddresses,
     } = this.props;
 
     let total = 0;
-    if (walletAddrs && walletAddrs.length) {
-      total = _.sumBy(walletAddrs, (wallet) => wallet.qtum ? wallet.qtum : 0);
+    if (walletAddresses && walletAddresses.length) {
+      total = _.sumBy(walletAddresses, (wallet) => wallet.qtum ? wallet.qtum : 0);
     }
 
     return total.toFixed(2);
@@ -97,12 +97,12 @@ class NavBar extends React.PureComponent {
 
   getTotalBOT() {
     const {
-      walletAddrs,
+      walletAddresses,
     } = this.props;
 
     let total = 0;
-    if (walletAddrs && walletAddrs.length) {
-      total = _.sumBy(walletAddrs, (wallet) => wallet.bot ? wallet.bot : 0);
+    if (walletAddresses && walletAddresses.length) {
+      total = _.sumBy(walletAddresses, (wallet) => wallet.bot ? wallet.bot : 0);
     }
 
     return total.toFixed(2);
@@ -111,13 +111,13 @@ class NavBar extends React.PureComponent {
 
 NavBar.propTypes = {
   classes: PropTypes.object.isRequired,
-  walletAddrs: PropTypes.array,
+  walletAddresses: PropTypes.array,
   actionableItemCount: PropTypes.number,
   langHandler: PropTypes.func,
 };
 
 NavBar.defaultProps = {
-  walletAddrs: [],
+  walletAddresses: [],
   actionableItemCount: undefined,
   langHandler: undefined,
 };

--- a/src/redux/App/actions.js
+++ b/src/redux/App/actions.js
@@ -49,6 +49,11 @@ const appActions = {
     },
   }),
 
+  DISABLE_UPDATING_BALANCES: 'DISABLE_UPDATING_BALANCES',
+  disableUpdatingBalances: () => ({
+    type: appActions.DISABLE_UPDATING_BALANCES,
+  }),
+
   GET_SYNC_INFO: 'GET_SYNC_INFO',
   getSyncInfo: () => ({
     type: appActions.GET_SYNC_INFO,

--- a/src/redux/App/actions.js
+++ b/src/redux/App/actions.js
@@ -22,14 +22,15 @@ const appActions = {
   },
 
   ADD_WALLET_ADDRESS: 'ADD_WALLET_ADDRESS',
-  SELECT_WALLET_ADDRESS: 'SELECT_WALLET_ADDRESS',
   addWalletAddress: (value) => ({
     type: appActions.ADD_WALLET_ADDRESS,
     value,
   }),
-  selectWalletAddress: (value) => ({
+
+  SELECT_WALLET_ADDRESS: 'SELECT_WALLET_ADDRESS',
+  selectWalletAddress: (address) => ({
     type: appActions.SELECT_WALLET_ADDRESS,
-    value,
+    address,
   }),
 
   LIST_UNSPENT: 'LIST_UNSPENT',

--- a/src/redux/App/actions.js
+++ b/src/redux/App/actions.js
@@ -27,9 +27,9 @@ const appActions = {
     value,
   }),
 
-  SELECT_WALLET_ADDRESS: 'SELECT_WALLET_ADDRESS',
-  selectWalletAddress: (address) => ({
-    type: appActions.SELECT_WALLET_ADDRESS,
+  SET_LAST_USED_ADDRESS: 'SET_LAST_USED_ADDRESS',
+  setLastUsedAddress: (address) => ({
+    type: appActions.SET_LAST_USED_ADDRESS,
     address,
   }),
 

--- a/src/redux/App/reducer.js
+++ b/src/redux/App/reducer.js
@@ -12,7 +12,7 @@ const initState = new Map({
   height: window.innerHeight,
   current: preKeys,
   walletAddresses: [],
-  selectedWalletAddress: '',
+  lastUsedAddress: '',
   updatingBalances: false,
   syncProgress: 0,
   initSyncing: false,
@@ -26,7 +26,7 @@ export default function appReducer(state = initState, action) {
       return state.set('walletAddresses', addresses);
     }
     case actions.SELECT_WALLET_ADDRESS: {
-      return state.set('selectedWalletAddress', action.address);
+      return state.set('lastUsedAddress', action.address);
     }
     case actions.LIST_UNSPENT_RETURN: {
       if (action.error) {
@@ -63,14 +63,14 @@ export default function appReducer(state = initState, action) {
       newAddresses = _.orderBy(newAddresses, ['qtum'], ['desc']);
 
       // Set a default selected address if there was none selected before
-      let selectedWalletAddress = state.get('selectedWalletAddress');
-      if (_.isEmpty(selectedWalletAddress) && !_.isEmpty(newAddresses)) {
-        selectedWalletAddress = newAddresses[0].address;
+      let lastUsedAddress = state.get('lastUsedAddress');
+      if (_.isEmpty(lastUsedAddress) && !_.isEmpty(newAddresses)) {
+        lastUsedAddress = newAddresses[0].address;
       }
 
       return state.set('walletAddresses', newAddresses)
         .set('utxos', action.value.utxos)
-        .set('selectedWalletAddress', selectedWalletAddress)
+        .set('lastUsedAddress', lastUsedAddress)
         .set('updatingBalances', true);
     }
     case actions.GET_BOT_BALANCE_RETURN: {

--- a/src/redux/App/reducer.js
+++ b/src/redux/App/reducer.js
@@ -25,7 +25,7 @@ export default function appReducer(state = initState, action) {
       addresses.push({ address: action.value, qtum: 0 });
       return state.set('walletAddresses', addresses);
     }
-    case actions.SELECT_WALLET_ADDRESS: {
+    case actions.SET_LAST_USED_ADDRESS: {
       return state.set('lastUsedAddress', action.address);
     }
     case actions.LIST_UNSPENT_RETURN: {

--- a/src/redux/App/reducer.js
+++ b/src/redux/App/reducer.js
@@ -78,16 +78,11 @@ export default function appReducer(state = initState, action) {
       }
 
       const walletAddresses = state.get('walletAddresses');
+      const { address, botAmount } = action.value;
 
-      if (action && action.value) {
-        const ownerAddress = action.value.address;
-        const ownerBotBalance = action.value.value;
-
-        const ownerObj = _.find(walletAddresses, (item) => item.address === ownerAddress);
-
-        if (ownerObj) {
-          ownerObj.bot = ownerBotBalance;
-        }
+      const ownerObj = _.find(walletAddresses, (item) => item.address === address);
+      if (ownerObj) {
+        ownerObj.bot = botAmount;
       }
 
       return state.set('walletAddresses', walletAddresses);

--- a/src/redux/App/reducer.js
+++ b/src/redux/App/reducer.js
@@ -26,16 +26,7 @@ export default function appReducer(state = initState, action) {
       return state.set('walletAddresses', addresses);
     }
     case actions.SELECT_WALLET_ADDRESS: {
-      const walletAddrsIndex = action.value;
-      const walletAddresses = state.get('walletAddresses');
-
-      if (!_.isEmpty(walletAddresses)
-        && walletAddrsIndex < walletAddresses.length
-        && !_.isUndefined(walletAddresses[walletAddrsIndex])) {
-        const newState = state.set('walletAddrsIndex', walletAddrsIndex);
-        return newState.set('selectedWalletAddress', walletAddresses[walletAddrsIndex].address);
-      }
-      return state;
+      return state.set('selectedWalletAddress', action.address);
     }
     case actions.LIST_UNSPENT_RETURN: {
       const newAddresses = action.value.addresses;
@@ -48,7 +39,7 @@ export default function appReducer(state = initState, action) {
         const index = _.findIndex(newAddresses, { address: addressObj.address });
         if (index !== -1) {
           // Set the bot balance of the old address to the new one
-          newAddresses.splice(index, 1, { 
+          newAddresses.splice(index, 1, {
             address: addressObj.address,
             qtum: newAddresses[index].qtum,
             bot: addressObj.bot,
@@ -63,7 +54,7 @@ export default function appReducer(state = initState, action) {
         }
       });
 
-      return newState.set('walletAddresses', newAddresses).set('utxos', action.value.utxos);
+      return state.set('walletAddresses', newAddresses).set('utxos', action.value.utxos);
 
       // if (_.isEmpty(existingAddresses)) {
       //   existingAddresses = combinedAddresses;

--- a/src/redux/App/reducer.js
+++ b/src/redux/App/reducer.js
@@ -12,7 +12,6 @@ const initState = new Map({
   height: window.innerHeight,
   current: preKeys,
   walletAddresses: [],
-  walletAddrs: [],
   walletAddrsIndex: 0,
   selectedWalletAddress: '',
   syncProgress: 0,
@@ -22,19 +21,19 @@ const initState = new Map({
 export default function appReducer(state = initState, action) {
   switch (action.type) {
     case actions.ADD_WALLET_ADDRESS: {
-      const addresses = state.get('walletAddrs');
+      const addresses = state.get('walletAddresses');
       addresses.push({ address: action.value, qtum: 0 });
-      return state.set('walletAddrs', addresses);
+      return state.set('walletAddresses', addresses);
     }
     case actions.SELECT_WALLET_ADDRESS: {
       const walletAddrsIndex = action.value;
-      const walletAddrs = state.get('walletAddrs');
+      const walletAddresses = state.get('walletAddresses');
 
-      if (!_.isEmpty(walletAddrs)
-        && walletAddrsIndex < walletAddrs.length
-        && !_.isUndefined(walletAddrs[walletAddrsIndex])) {
+      if (!_.isEmpty(walletAddresses)
+        && walletAddrsIndex < walletAddresses.length
+        && !_.isUndefined(walletAddresses[walletAddrsIndex])) {
         const newState = state.set('walletAddrsIndex', walletAddrsIndex);
-        return newState.set('selectedWalletAddress', walletAddrs[walletAddrsIndex].address);
+        return newState.set('selectedWalletAddress', walletAddresses[walletAddrsIndex].address);
       }
       return state;
     }
@@ -82,20 +81,20 @@ export default function appReducer(state = initState, action) {
       // return newState.set('walletAddrs', existingAddresses);
     }
     case actions.GET_BOT_BALANCE_RETURN: {
-      const walletAddrs = state.get('walletAddrs');
+      const walletAddresses = state.get('walletAddresses');
 
       if (action && action.value) {
         const ownerAddress = action.value.address;
         const ownerBotBalance = action.value.value;
 
-        const ownerObj = _.find(walletAddrs, (item) => item.address === ownerAddress);
+        const ownerObj = _.find(walletAddresses, (item) => item.address === ownerAddress);
 
         if (ownerObj) {
           ownerObj.bot = ownerBotBalance;
         }
       }
 
-      return state.set('walletAddrs', walletAddrs);
+      return state.set('walletAddresses', walletAddresses);
     }
     case actions.TOGGLE_ALL: {
       if (state.get('view') !== action.view || action.height !== state.height) {

--- a/src/redux/App/reducer.js
+++ b/src/redux/App/reducer.js
@@ -12,7 +12,6 @@ const initState = new Map({
   height: window.innerHeight,
   current: preKeys,
   walletAddresses: [],
-  walletAddrsIndex: 0,
   selectedWalletAddress: '',
   syncProgress: 0,
   initSyncing: false,

--- a/src/redux/App/reducer.js
+++ b/src/redux/App/reducer.js
@@ -38,6 +38,8 @@ export default function appReducer(state = initState, action) {
       return state;
     }
     case actions.LIST_UNSPENT_RETURN: {
+      console.log(action.value);
+
       let result = [];
       let newState = state;
       let combinedAddresses = [];

--- a/src/redux/App/reducer.js
+++ b/src/redux/App/reducer.js
@@ -28,7 +28,7 @@ export default function appReducer(state = initState, action) {
       return state.set('selectedWalletAddress', action.address);
     }
     case actions.LIST_UNSPENT_RETURN: {
-      const newAddresses = action.value.addresses;
+      let newAddresses = action.value.addresses;
 
       // Update the bot balance of the existing addresses or add in existing addresses but with 0 qtum balance.
       // This is for good UX so the user won't wonder why their old address which they did a sendtoaddress
@@ -52,6 +52,9 @@ export default function appReducer(state = initState, action) {
           });
         }
       });
+
+      // Sort
+      newAddresses = _.orderBy(newAddresses, ['qtum'], ['desc']);
 
       // Set a default selected address if there was none selected before
       let selectedWalletAddress = state.get('selectedWalletAddress');

--- a/src/redux/App/reducer.js
+++ b/src/redux/App/reducer.js
@@ -28,6 +28,11 @@ export default function appReducer(state = initState, action) {
       return state.set('selectedWalletAddress', action.address);
     }
     case actions.LIST_UNSPENT_RETURN: {
+      if (action.error) {
+        console.error('Error fetching listunspent');
+        return state;
+      }
+
       let newAddresses = action.value.addresses;
 
       // Update the bot balance of the existing addresses or add in existing addresses but with 0 qtum balance.
@@ -67,6 +72,11 @@ export default function appReducer(state = initState, action) {
         .set('selectedWalletAddress', selectedWalletAddress);
     }
     case actions.GET_BOT_BALANCE_RETURN: {
+      if (action.error) {
+        console.error('Error fetching bot-balance');
+        return state;
+      }
+
       const walletAddresses = state.get('walletAddresses');
 
       if (action && action.value) {

--- a/src/redux/App/reducer.js
+++ b/src/redux/App/reducer.js
@@ -13,6 +13,7 @@ const initState = new Map({
   current: preKeys,
   walletAddresses: [],
   selectedWalletAddress: '',
+  updatingBalances: false,
   syncProgress: 0,
   initSyncing: false,
 });
@@ -69,7 +70,8 @@ export default function appReducer(state = initState, action) {
 
       return state.set('walletAddresses', newAddresses)
         .set('utxos', action.value.utxos)
-        .set('selectedWalletAddress', selectedWalletAddress);
+        .set('selectedWalletAddress', selectedWalletAddress)
+        .set('updatingBalances', true);
     }
     case actions.GET_BOT_BALANCE_RETURN: {
       if (action.error) {
@@ -86,6 +88,9 @@ export default function appReducer(state = initState, action) {
       }
 
       return state.set('walletAddresses', walletAddresses);
+    }
+    case actions.DISABLE_UPDATING_BALANCES: {
+      return state.set('updatingBalances', false);
     }
     case actions.TOGGLE_ALL: {
       if (state.get('view') !== action.view || action.height !== state.height) {

--- a/src/redux/App/reducer.js
+++ b/src/redux/App/reducer.js
@@ -54,22 +54,15 @@ export default function appReducer(state = initState, action) {
         }
       });
 
-      return state.set('walletAddresses', newAddresses).set('utxos', action.value.utxos);
+      // Set a default selected address if there was none selected before
+      let selectedWalletAddress = state.get('selectedWalletAddress');
+      if (_.isEmpty(selectedWalletAddress) && !_.isEmpty(newAddresses)) {
+        selectedWalletAddress = newAddresses[0].address;
+      }
 
-      // if (_.isEmpty(existingAddresses)) {
-      //   existingAddresses = combinedAddresses;
-
-      //   // If initalizing, set initial value for selectedWalletAddress here
-      //   newState = state.set('selectedWalletAddress', result[state.get('walletAddrsIndex')]
-      //     && result[state.get('walletAddrsIndex')].address);
-      // } else { // Update existing address list if new is different
-      //   _.each(existingAddresses, (item) => {
-      //     const newAddressObj = _.find(combinedAddresses, { address: item.address });
-      //     _.extend(item, newAddressObj);
-      //   });
-      // }
-
-      // return newState.set('walletAddrs', existingAddresses);
+      return state.set('walletAddresses', newAddresses)
+        .set('utxos', action.value.utxos)
+        .set('selectedWalletAddress', selectedWalletAddress);
     }
     case actions.GET_BOT_BALANCE_RETURN: {
       const walletAddresses = state.get('walletAddresses');

--- a/src/redux/App/saga.js
+++ b/src/redux/App/saga.js
@@ -76,9 +76,6 @@ function processListUnspent(utxos) {
     }
   });
 
-  // Sort
-  addresses = _.orderBy(addresses, ['qtum'], ['desc']);
-
   return {
     utxos: trimmedUtxos,
     addresses,

--- a/src/redux/App/saga.js
+++ b/src/redux/App/saga.js
@@ -106,7 +106,7 @@ export function* getBotBalanceRequestHandler() {
         type: actions.GET_BOT_BALANCE_RETURN,
         value: {
           address: owner,
-          value: botValue,
+          botAmount: botValue,
         },
       });
     } catch (error) {

--- a/src/redux/App/saga.js
+++ b/src/redux/App/saga.js
@@ -37,7 +37,6 @@ export function* listUnspentRequestHandler() {
       } else {
         // listunspent returned with a non-empty array
         const utxosAndAddresses = processListUnspent(result);
-        console.log(utxosAndAddresses);
 
         yield put({
           type: actions.LIST_UNSPENT_RETURN,
@@ -57,7 +56,8 @@ function processListUnspent(utxos) {
   const trimmedUtxos = _.map(utxos, (output) =>
     _.pick(output, ['address', 'amount', 'txid', 'vout', 'confirmations', 'spendable']));
 
-  const addresses = [];
+  let addresses = [];
+
   // Combine utxos with same address
   _.each(trimmedUtxos, (output) => {
     const currentAddr = output.address;
@@ -75,6 +75,9 @@ function processListUnspent(utxos) {
       });
     }
   });
+
+  // Sort
+  addresses = _.orderBy(addresses, ['qtum'], ['desc']);
 
   return {
     utxos: trimmedUtxos,

--- a/src/redux/App/saga.js
+++ b/src/redux/App/saga.js
@@ -36,11 +36,11 @@ export function* listUnspentRequestHandler() {
         });
       } else {
         // listunspent returned with a non-empty array
-        const utxosAndAddresses = processListUnspent(result);
+        const addresses = processListUnspent(result);
 
         yield put({
           type: actions.LIST_UNSPENT_RETURN,
-          value: utxosAndAddresses,
+          value: addresses,
         });
       }
     } catch (error) {

--- a/src/redux/App/saga.js
+++ b/src/redux/App/saga.js
@@ -46,7 +46,7 @@ export function* listUnspentRequestHandler() {
     } catch (error) {
       yield put({
         type: actions.LIST_UNSPENT_RETURN,
-        value: { error: error.message ? error.message : '' },
+        error: error.message,
       });
     }
   });
@@ -112,7 +112,7 @@ export function* getBotBalanceRequestHandler() {
     } catch (error) {
       yield put({
         type: actions.GET_BOT_BALANCE_RETURN,
-        value: { error: error.message ? error.message : '' },
+        error: error.message,
       });
     }
   });

--- a/src/redux/App/saga.js
+++ b/src/redux/App/saga.js
@@ -56,7 +56,7 @@ function processListUnspent(utxos) {
   const trimmedUtxos = _.map(utxos, (output) =>
     _.pick(output, ['address', 'amount', 'txid', 'vout', 'confirmations', 'spendable']));
 
-  let addresses = [];
+  const addresses = [];
 
   // Combine utxos with same address
   _.each(trimmedUtxos, (output) => {

--- a/src/scenes/App/globalHub.jsx
+++ b/src/scenes/App/globalHub.jsx
@@ -45,7 +45,7 @@ class GlobalHub extends React.PureComponent {
       syncBlockNum,
       getActionableItemCount,
       walletAddresses,
-      selectedWalletAddress,
+      lastUsedAddress,
       disableUpdatingBalances,
     } = this.props;
 
@@ -66,8 +66,8 @@ class GlobalHub extends React.PureComponent {
     }
 
     // Gets the actionable items for the My Activities badge
-    if (nextProps.selectedWalletAddress !== selectedWalletAddress) {
-      getActionableItemCount(nextProps.selectedWalletAddress);
+    if (nextProps.lastUsedAddress !== lastUsedAddress) {
+      getActionableItemCount(nextProps.lastUsedAddress);
     }
   }
 
@@ -121,7 +121,7 @@ GlobalHub.propTypes = {
   initSyncing: PropTypes.bool.isRequired,
   syncBlockNum: PropTypes.number,
   walletAddresses: PropTypes.array,
-  selectedWalletAddress: PropTypes.string.isRequired,
+  lastUsedAddress: PropTypes.string.isRequired,
   updatingBalances: PropTypes.bool.isRequired,
   disableUpdatingBalances: PropTypes.func.isRequired,
   getSyncInfo: PropTypes.func,
@@ -146,7 +146,7 @@ const mapStateToProps = (state) => ({
   initSyncing: state.App.get('initSyncing'),
   syncBlockNum: state.App.get('syncBlockNum'),
   walletAddresses: state.App.get('walletAddresses'),
-  selectedWalletAddress: state.App.get('selectedWalletAddress'),
+  lastUsedAddress: state.App.get('lastUsedAddress'),
   updatingBalances: state.App.get('updatingBalances'),
 });
 

--- a/src/scenes/App/globalHub.jsx
+++ b/src/scenes/App/globalHub.jsx
@@ -24,7 +24,7 @@ class GlobalHub extends React.PureComponent {
   }
 
   componentWillMount() {
-    const { walletAddrs } = this.props;
+    const { walletAddresses } = this.props;
 
     // Start syncInfo long polling
     // We use this to update the percentage of the loading screen
@@ -35,7 +35,7 @@ class GlobalHub extends React.PureComponent {
     this.subscribeSyncInfo();
 
     // Get unspent outputs and bot balances for all the wallet addresses
-    this.updateBalances(walletAddrs);
+    this.updateBalances(walletAddresses);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -54,7 +54,7 @@ class GlobalHub extends React.PureComponent {
     // Update balances after init sync and on new block
     if ((!nextProps.initSyncing && nextProps.syncBlockNum !== syncBlockNum)
       || (initSyncing && !nextProps.initSyncing)) {
-      this.updateBalances(nextProps.walletAddrs);
+      this.updateBalances(nextProps.walletAddresses);
 
       // Gets the actionable items for the My Activities badge
       if (!_.isEmpty(nextProps.selectedWalletAddress)) {
@@ -110,7 +110,7 @@ GlobalHub.propTypes = {
   client: PropTypes.object,
   initSyncing: PropTypes.bool.isRequired,
   syncBlockNum: PropTypes.number,
-  walletAddrs: PropTypes.array,
+  walletAddresses: PropTypes.array,
   selectedWalletAddress: PropTypes.string,
   getSyncInfo: PropTypes.func,
   onSyncInfo: PropTypes.func,
@@ -122,7 +122,7 @@ GlobalHub.propTypes = {
 GlobalHub.defaultProps = {
   client: undefined,
   syncBlockNum: undefined,
-  walletAddrs: [],
+  walletAddresses: [],
   selectedWalletAddress: undefined,
   getSyncInfo: undefined,
   onSyncInfo: undefined,
@@ -135,7 +135,7 @@ const mapStateToProps = (state) => ({
   ...state.App.toJS(),
   initSyncing: state.App.get('initSyncing'),
   syncBlockNum: state.App.get('syncBlockNum'),
-  walletAddrs: state.App.get('walletAddrs'),
+  walletAddresses: state.App.get('walletAddresses'),
   selectedWalletAddress: state.App.get('selectedWalletAddress'),
 });
 

--- a/src/scenes/App/globalHub.jsx
+++ b/src/scenes/App/globalHub.jsx
@@ -55,11 +55,11 @@ class GlobalHub extends React.PureComponent {
     if ((!nextProps.initSyncing && nextProps.syncBlockNum !== syncBlockNum)
       || (initSyncing && !nextProps.initSyncing)) {
       this.updateBalances(nextProps.walletAddresses);
+    }
 
-      // Gets the actionable items for the My Activities badge
-      if (nextProps.selectedWalletAddress !== selectedWalletAddress) {
-        getActionableItemCount(nextProps.selectedWalletAddress);
-      }
+    // Gets the actionable items for the My Activities badge
+    if (nextProps.selectedWalletAddress !== selectedWalletAddress) {
+      getActionableItemCount(nextProps.selectedWalletAddress);
     }
   }
 
@@ -116,7 +116,7 @@ GlobalHub.propTypes = {
   onSyncInfo: PropTypes.func,
   listUnspent: PropTypes.func,
   getBotBalance: PropTypes.func,
-  getActionableItemCount: PropTypes.func,
+  getActionableItemCount: PropTypes.func.isRequired,
 };
 
 GlobalHub.defaultProps = {
@@ -127,7 +127,6 @@ GlobalHub.defaultProps = {
   onSyncInfo: undefined,
   listUnspent: undefined,
   getBotBalance: undefined,
-  getActionableItemCount: undefined,
 };
 
 const mapStateToProps = (state) => ({

--- a/src/scenes/App/globalHub.jsx
+++ b/src/scenes/App/globalHub.jsx
@@ -57,7 +57,7 @@ class GlobalHub extends React.PureComponent {
       this.updateBalances(nextProps.walletAddresses);
 
       // Gets the actionable items for the My Activities badge
-      if (!_.isEmpty(nextProps.selectedWalletAddress)) {
+      if (nextProps.selectedWalletAddress !== selectedWalletAddress) {
         getActionableItemCount(nextProps.selectedWalletAddress);
       }
     }
@@ -111,7 +111,7 @@ GlobalHub.propTypes = {
   initSyncing: PropTypes.bool.isRequired,
   syncBlockNum: PropTypes.number,
   walletAddresses: PropTypes.array,
-  selectedWalletAddress: PropTypes.string,
+  selectedWalletAddress: PropTypes.string.isRequired,
   getSyncInfo: PropTypes.func,
   onSyncInfo: PropTypes.func,
   listUnspent: PropTypes.func,
@@ -123,7 +123,6 @@ GlobalHub.defaultProps = {
   client: undefined,
   syncBlockNum: undefined,
   walletAddresses: [],
-  selectedWalletAddress: undefined,
   getSyncInfo: undefined,
   onSyncInfo: undefined,
   listUnspent: undefined,

--- a/src/scenes/CreateTopic/components/createTopic.js
+++ b/src/scenes/CreateTopic/components/createTopic.js
@@ -113,7 +113,6 @@ class CreateTopic extends React.Component {
       resultSettingEndBlock: undefined,
     };
 
-    this.getCurrentSenderAddress = this.getCurrentSenderAddress.bind(this);
     this.renderBlockField = this.renderBlockField.bind(this);
     this.renderResultsFields = this.renderResultsFields.bind(this);
     this.onDatePickerDateSelect = this.onDatePickerDateSelect.bind(this);
@@ -264,17 +263,6 @@ class CreateTopic extends React.Component {
         </Form>
       </div>
     );
-  }
-
-  getCurrentSenderAddress() {
-    const { walletAddresses, walletAddrsIndex } = this.props;
-
-    if (!_.isEmpty(walletAddresses)
-      && walletAddrsIndex < walletAddresses.length
-      && !_.isUndefined(walletAddresses[walletAddrsIndex])) {
-      return walletAddresses[walletAddrsIndex].address;
-    }
-    return '';
   }
 
   renderBlockField(formItemLayout, id) {
@@ -572,9 +560,11 @@ class CreateTopic extends React.Component {
   }
 
   handleSubmit(evt) {
+    const { form, selectedWalletAddress } = this.props;
+
     evt.preventDefault();
 
-    this.props.form.validateFieldsAndScroll((err, values) => {
+    form.validateFieldsAndScroll((err, values) => {
       if (!err) {
         const {
           name,
@@ -594,7 +584,7 @@ class CreateTopic extends React.Component {
           bettingEndTime.utc().unix().toString(),
           resultSettingStartTime.utc().unix().toString(),
           resultSettingEndTime.utc().unix().toString(),
-          this.getCurrentSenderAddress()
+          selectedWalletAddress,
         );
       }
     });
@@ -615,8 +605,7 @@ CreateTopic.propTypes = {
   createTopicTx: PropTypes.func,
   txReturn: PropTypes.object,
   getInsightTotals: PropTypes.func,
-  walletAddresses: PropTypes.array,
-  walletAddrsIndex: PropTypes.number,
+  selectedWalletAddress: PropTypes.string.isRequired,
   chainBlockNum: PropTypes.number,
   averageBlockTime: PropTypes.number,
   // eslint-disable-next-line react/no-typos
@@ -627,16 +616,13 @@ CreateTopic.defaultProps = {
   createTopicTx: undefined,
   txReturn: undefined,
   getInsightTotals: undefined,
-  walletAddresses: [],
-  walletAddrsIndex: 0,
   chainBlockNum: undefined,
   averageBlockTime: defaults.averageBlockTime,
 };
 
 const mapStateToProps = (state) => ({
   txReturn: state.Graphql.get('txReturn'),
-  walletAddresses: state.App.get('walletAddresses'),
-  walletAddrsIndex: state.App.get('walletAddrsIndex'),
+  selectedWalletAddress: state.App.get('selectedWalletAddress'),
   chainBlockNum: state.App.get('chainBlockNum'),
   averageBlockTime: state.App.get('averageBlockTime'),
 });

--- a/src/scenes/CreateTopic/components/createTopic.js
+++ b/src/scenes/CreateTopic/components/createTopic.js
@@ -560,7 +560,7 @@ class CreateTopic extends React.Component {
   }
 
   handleSubmit(evt) {
-    const { form, selectedWalletAddress } = this.props;
+    const { form, lastUsedAddress } = this.props;
 
     evt.preventDefault();
 
@@ -584,7 +584,7 @@ class CreateTopic extends React.Component {
           bettingEndTime.utc().unix().toString(),
           resultSettingStartTime.utc().unix().toString(),
           resultSettingEndTime.utc().unix().toString(),
-          selectedWalletAddress,
+          lastUsedAddress,
         );
       }
     });
@@ -605,7 +605,7 @@ CreateTopic.propTypes = {
   createTopicTx: PropTypes.func,
   txReturn: PropTypes.object,
   getInsightTotals: PropTypes.func,
-  selectedWalletAddress: PropTypes.string.isRequired,
+  lastUsedAddress: PropTypes.string.isRequired,
   chainBlockNum: PropTypes.number,
   averageBlockTime: PropTypes.number,
   // eslint-disable-next-line react/no-typos
@@ -622,7 +622,7 @@ CreateTopic.defaultProps = {
 
 const mapStateToProps = (state) => ({
   txReturn: state.Graphql.get('txReturn'),
-  selectedWalletAddress: state.App.get('selectedWalletAddress'),
+  lastUsedAddress: state.App.get('lastUsedAddress'),
   chainBlockNum: state.App.get('chainBlockNum'),
   averageBlockTime: state.App.get('averageBlockTime'),
 });

--- a/src/scenes/CreateTopic/components/createTopic.js
+++ b/src/scenes/CreateTopic/components/createTopic.js
@@ -267,12 +267,12 @@ class CreateTopic extends React.Component {
   }
 
   getCurrentSenderAddress() {
-    const { walletAddrs, walletAddrsIndex } = this.props;
+    const { walletAddresses, walletAddrsIndex } = this.props;
 
-    if (!_.isEmpty(walletAddrs)
-      && walletAddrsIndex < walletAddrs.length
-      && !_.isUndefined(walletAddrs[walletAddrsIndex])) {
-      return walletAddrs[walletAddrsIndex].address;
+    if (!_.isEmpty(walletAddresses)
+      && walletAddrsIndex < walletAddresses.length
+      && !_.isUndefined(walletAddresses[walletAddrsIndex])) {
+      return walletAddresses[walletAddrsIndex].address;
     }
     return '';
   }
@@ -615,7 +615,7 @@ CreateTopic.propTypes = {
   createTopicTx: PropTypes.func,
   txReturn: PropTypes.object,
   getInsightTotals: PropTypes.func,
-  walletAddrs: PropTypes.array,
+  walletAddresses: PropTypes.array,
   walletAddrsIndex: PropTypes.number,
   chainBlockNum: PropTypes.number,
   averageBlockTime: PropTypes.number,
@@ -627,7 +627,7 @@ CreateTopic.defaultProps = {
   createTopicTx: undefined,
   txReturn: undefined,
   getInsightTotals: undefined,
-  walletAddrs: [],
+  walletAddresses: [],
   walletAddrsIndex: 0,
   chainBlockNum: undefined,
   averageBlockTime: defaults.averageBlockTime,
@@ -635,7 +635,7 @@ CreateTopic.defaultProps = {
 
 const mapStateToProps = (state) => ({
   txReturn: state.Graphql.get('txReturn'),
-  walletAddrs: state.App.get('walletAddrs'),
+  walletAddresses: state.App.get('walletAddresses'),
   walletAddrsIndex: state.App.get('walletAddrsIndex'),
   chainBlockNum: state.App.get('chainBlockNum'),
   averageBlockTime: state.App.get('averageBlockTime'),

--- a/src/scenes/Event/components/EventOption/index.js
+++ b/src/scenes/Event/components/EventOption/index.js
@@ -38,7 +38,6 @@ class EventOption extends React.PureComponent {
       voteAmount,
       token,
       walletAddresses,
-      currentWalletIdx,
       skipExpansion,
       showAmountInput,
     } = this.props;
@@ -110,8 +109,16 @@ class EventOption extends React.PureComponent {
     const {
       classes,
       walletAddresses,
-      currentWalletIdx,
+      selectedWalletAddress,
     } = this.props;
+
+    // Add the unselected item to the front
+    // const addresses = walletAddresses;
+    // addresses.unshift({
+    //   address: '',
+    //   qtum: 0,
+    //   bot: 0,
+    // });
 
     return (<ExpansionPanelDetails>
       <div className={classNames(classes.eventOptionWrapper, 'noMargin', 'last')}>
@@ -124,14 +131,14 @@ class EventOption extends React.PureComponent {
           </InputLabel>
           <Select
             native
-            value={currentWalletIdx}
+            value={selectedWalletAddress}
             onChange={this.handleAddrChange}
             inputProps={{
               id: 'address',
             }}
           >
             {walletAddresses.map((item, index) => (
-              <option key={item.address} value={index}>{item.address}</option>
+              <option key={item.address} value={item.address}>{item.address}</option>
             ))}
           </Select>
         </FormControl>
@@ -179,7 +186,7 @@ EventOption.propTypes = {
   onAmountChange: PropTypes.func.isRequired,
   onWalletChange: PropTypes.func.isRequired,
   walletAddresses: PropTypes.array.isRequired,
-  currentWalletIdx: PropTypes.number.isRequired,
+  selectedWalletAddress: PropTypes.number.isRequired,
   skipExpansion: PropTypes.bool.isRequired,
   showAmountInput: PropTypes.bool.isRequired,
 };

--- a/src/scenes/Event/components/EventOption/index.js
+++ b/src/scenes/Event/components/EventOption/index.js
@@ -112,14 +112,6 @@ class EventOption extends React.PureComponent {
       selectedWalletAddress,
     } = this.props;
 
-    // Add the unselected item to the front
-    // const addresses = walletAddresses;
-    // addresses.unshift({
-    //   address: '',
-    //   qtum: 0,
-    //   bot: 0,
-    // });
-
     return (<ExpansionPanelDetails>
       <div className={classNames(classes.eventOptionWrapper, 'noMargin', 'last')}>
         <div className={classes.eventOptionIcon}>

--- a/src/scenes/Event/components/EventOption/index.js
+++ b/src/scenes/Event/components/EventOption/index.js
@@ -37,7 +37,7 @@ class EventOption extends React.PureComponent {
       percent,
       voteAmount,
       token,
-      walletAddrs,
+      walletAddresses,
       currentWalletIdx,
       skipExpansion,
       showAmountInput,
@@ -109,7 +109,7 @@ class EventOption extends React.PureComponent {
   renderAddrSelect() {
     const {
       classes,
-      walletAddrs,
+      walletAddresses,
       currentWalletIdx,
     } = this.props;
 
@@ -130,7 +130,7 @@ class EventOption extends React.PureComponent {
               id: 'address',
             }}
           >
-            {walletAddrs.map((item, index) => (
+            {walletAddresses.map((item, index) => (
               <option key={item.address} value={index}>{item.address}</option>
             ))}
           </Select>
@@ -178,7 +178,7 @@ EventOption.propTypes = {
   onOptionChange: PropTypes.func.isRequired,
   onAmountChange: PropTypes.func.isRequired,
   onWalletChange: PropTypes.func.isRequired,
-  walletAddrs: PropTypes.array.isRequired,
+  walletAddresses: PropTypes.array.isRequired,
   currentWalletIdx: PropTypes.number.isRequired,
   skipExpansion: PropTypes.bool.isRequired,
   showAmountInput: PropTypes.bool.isRequired,

--- a/src/scenes/Event/components/EventOption/index.js
+++ b/src/scenes/Event/components/EventOption/index.js
@@ -178,7 +178,7 @@ EventOption.propTypes = {
   onAmountChange: PropTypes.func.isRequired,
   onWalletChange: PropTypes.func.isRequired,
   walletAddresses: PropTypes.array.isRequired,
-  selectedWalletAddress: PropTypes.number.isRequired,
+  selectedWalletAddress: PropTypes.string.isRequired,
   skipExpansion: PropTypes.bool.isRequired,
   showAmountInput: PropTypes.bool.isRequired,
 };

--- a/src/scenes/Event/components/EventOption/index.js
+++ b/src/scenes/Event/components/EventOption/index.js
@@ -109,7 +109,7 @@ class EventOption extends React.PureComponent {
     const {
       classes,
       walletAddresses,
-      selectedWalletAddress,
+      lastUsedAddress,
     } = this.props;
 
     return (<ExpansionPanelDetails>
@@ -123,7 +123,7 @@ class EventOption extends React.PureComponent {
           </InputLabel>
           <Select
             native
-            value={selectedWalletAddress}
+            value={lastUsedAddress}
             onChange={this.handleAddrChange}
             inputProps={{
               id: 'address',
@@ -178,7 +178,7 @@ EventOption.propTypes = {
   onAmountChange: PropTypes.func.isRequired,
   onWalletChange: PropTypes.func.isRequired,
   walletAddresses: PropTypes.array.isRequired,
-  selectedWalletAddress: PropTypes.string.isRequired,
+  lastUsedAddress: PropTypes.string.isRequired,
   skipExpansion: PropTypes.bool.isRequired,
   showAmountInput: PropTypes.bool.isRequired,
 };

--- a/src/scenes/Event/scenes/oracle.js
+++ b/src/scenes/Event/scenes/oracle.js
@@ -89,6 +89,7 @@ class OraclePage extends React.Component {
     const { classes, txReturn, selectedWalletAddress } = this.props;
     const { oracle, transactions, config } = this.state;
 
+    // TODO: is this necessary?
     if (!oracle || !config) {
       // Don't render anything if page is loading.
       // In future we could make a loading animation
@@ -195,31 +196,29 @@ class OraclePage extends React.Component {
   }
 
   handleConfirmClick() {
-    console.log(this.props.selectedWalletAddress);
-    // const amount = this.state.voteAmount;
+    const amount = this.state.voteAmount;
 
-    // switch (this.state.config.name) {
-    //   case 'BETTING': {
-    //     this.bet(amount);
-    //     break;
-    //   }
-    //   case 'SETTING': {
-    //     this.setResult();
-    //     break;
-    //   }
-    //   case 'VOTING': {
-    //     this.vote(amount);
-    //     break;
-    //   }
-    //   case 'FINALIZING': {
-    //     this.finalizeResult();
-    //     break;
-    //   }
-    //   default: {
-    //     // TODO: oracle not found page
-    //     break;
-    //   }
-    // }
+    switch (this.state.config.name) {
+      case 'BETTING': {
+        this.bet(amount);
+        break;
+      }
+      case 'SETTING': {
+        this.setResult();
+        break;
+      }
+      case 'VOTING': {
+        this.vote(amount);
+        break;
+      }
+      case 'FINALIZING': {
+        this.finalizeResult();
+        break;
+      }
+      default: {
+        break;
+      }
+    }
   }
 
   /**
@@ -467,7 +466,7 @@ OraclePage.propTypes = {
   createFinalizeResultTx: PropTypes.func,
   txReturn: PropTypes.object,
   syncBlockTime: PropTypes.number,
-  walletAddresses: PropTypes.array,
+  walletAddresses: PropTypes.array.isRequired,
   selectedWalletAddress: PropTypes.string.isRequired,
   selectWalletAddress: PropTypes.func.isRequired,
   // eslint-disable-next-line react/no-typos
@@ -485,7 +484,6 @@ OraclePage.defaultProps = {
   createFinalizeResultTx: undefined,
   txReturn: undefined,
   syncBlockTime: undefined,
-  walletAddresses: [],
 };
 
 const mapStateToProps = (state) => ({

--- a/src/scenes/Event/scenes/oracle.js
+++ b/src/scenes/Event/scenes/oracle.js
@@ -116,7 +116,7 @@ class OraclePage extends React.Component {
                   percent={item.percent}
                   voteAmount={this.state.voteAmount}
                   token={oracle.token}
-                  walletAddrs={this.props.walletAddrs}
+                  walletAddresses={this.props.walletAddresses}
                   currentWalletIdx={this.state.currentWalletIdx}
                   skipExpansion={config.predictionAction.skipExpansion}
                   showAmountInput={config.predictionAction.showAmountInput}
@@ -222,7 +222,7 @@ class OraclePage extends React.Component {
   }
 
   getCurrentWalletAddr() {
-    return this.props.walletAddrs[this.state.currentWalletIdx].address;
+    return this.props.walletAddresses[this.state.currentWalletIdx].address;
   }
 
   /**
@@ -462,7 +462,7 @@ OraclePage.propTypes = {
   createFinalizeResultTx: PropTypes.func,
   txReturn: PropTypes.object,
   syncBlockTime: PropTypes.number,
-  walletAddrs: PropTypes.array,
+  walletAddresses: PropTypes.array,
   walletAddrsIndex: PropTypes.number,
   // eslint-disable-next-line react/no-typos
   intl: intlShape.isRequired,
@@ -479,12 +479,12 @@ OraclePage.defaultProps = {
   createFinalizeResultTx: undefined,
   txReturn: undefined,
   syncBlockTime: undefined,
-  walletAddrs: [],
+  walletAddresses: [],
   walletAddrsIndex: 0,
 };
 
 const mapStateToProps = (state) => ({
-  walletAddrs: state.App.get('walletAddrs'),
+  walletAddresses: state.App.get('walletAddresses'),
   walletAddrsIndex: state.App.get('walletAddrsIndex'),
   syncBlockTime: state.App.get('syncBlockTime'),
   getOraclesReturn: state.Graphql.get('getOraclesReturn'),

--- a/src/scenes/Event/scenes/oracle.js
+++ b/src/scenes/Event/scenes/oracle.js
@@ -86,7 +86,7 @@ class OraclePage extends React.Component {
   }
 
   render() {
-    const { classes, txReturn, selectedWalletAddress } = this.props;
+    const { classes, txReturn, lastUsedAddress } = this.props;
     const { oracle, transactions, config } = this.state;
 
     // TODO: is this necessary?
@@ -118,7 +118,7 @@ class OraclePage extends React.Component {
                   voteAmount={this.state.voteAmount}
                   token={oracle.token}
                   walletAddresses={this.props.walletAddresses}
-                  selectedWalletAddress={selectedWalletAddress}
+                  lastUsedAddress={lastUsedAddress}
                   skipExpansion={config.predictionAction.skipExpansion}
                   showAmountInput={config.predictionAction.showAmountInput}
                   onOptionChange={this.handleOptionChange}
@@ -263,7 +263,7 @@ class OraclePage extends React.Component {
   }
 
   constructOracleAndConfig(getOraclesReturn, syncBlockTime) {
-    const { selectedWalletAddress } = this.props;
+    const { lastUsedAddress } = this.props;
 
     const oracle = _.find(getOraclesReturn, { address: this.state.address });
     const centralizedOracle = _.find(getOraclesReturn, { token: Token.Qtum });
@@ -314,7 +314,7 @@ class OraclePage extends React.Component {
             skipExpansion: false,
             btnText: <FormattedMessage id="str.setResult" defaultMessage="Set Result" />,
             btnDisabled: oracle.status === OracleStatus.WaitResult
-              && oracle.resultSetterQAddress !== selectedWalletAddress,
+              && oracle.resultSetterQAddress !== lastUsedAddress,
             showAmountInput: false,
           },
         };
@@ -328,7 +328,7 @@ class OraclePage extends React.Component {
         }
 
         // Add a message to CardInfo to warn that user is not result setter of current oracle
-        if (status === OracleStatus.WaitResult && oracle.resultSetterQAddress !== selectedWalletAddress) {
+        if (status === OracleStatus.WaitResult && oracle.resultSetterQAddress !== lastUsedAddress) {
           config.eventInfo.messages.push({
             text: <FormattedMessage id="oracle.notCen" defaultMessage="You are not the Centralized Oracle for this Topic and cannot set the result." />,
             type: 'warn',
@@ -401,7 +401,7 @@ class OraclePage extends React.Component {
       topicAddress,
       oracle,
       currentOptionIdx,
-      selectedWalletAddress,
+      lastUsedAddress,
     } = this.state;
     const selectedIndex = oracle.optionIdxs[currentOptionIdx];
 
@@ -411,13 +411,13 @@ class OraclePage extends React.Component {
       oracle.address,
       selectedIndex,
       amount.toString(),
-      selectedWalletAddress,
+      lastUsedAddress,
     );
   }
 
   setResult() {
     const { createSetResultTx } = this.props;
-    const { oracle, currentOptionIdx, selectedWalletAddress } = this.state;
+    const { oracle, currentOptionIdx, lastUsedAddress } = this.state;
     const selectedIndex = oracle.optionIdxs[currentOptionIdx];
 
     createSetResultTx(
@@ -426,13 +426,13 @@ class OraclePage extends React.Component {
       oracle.address,
       selectedIndex,
       oracle.consensusThreshold,
-      selectedWalletAddress,
+      lastUsedAddress,
     );
   }
 
   vote(amount) {
     const { createVoteTx } = this.props;
-    const { oracle, currentOptionIdx, selectedWalletAddress } = this.state;
+    const { oracle, currentOptionIdx, lastUsedAddress } = this.state;
     const selectedIndex = oracle.optionIdxs[currentOptionIdx];
 
     createVoteTx(
@@ -441,15 +441,15 @@ class OraclePage extends React.Component {
       oracle.address,
       selectedIndex,
       amount,
-      selectedWalletAddress,
+      lastUsedAddress,
     );
   }
 
   finalizeResult() {
     const { createFinalizeResultTx } = this.props;
-    const { oracle, selectedWalletAddress } = this.state;
+    const { oracle, lastUsedAddress } = this.state;
 
-    createFinalizeResultTx(oracle.version, oracle.topicAddress, oracle.address, selectedWalletAddress);
+    createFinalizeResultTx(oracle.version, oracle.topicAddress, oracle.address, lastUsedAddress);
   }
 }
 
@@ -467,7 +467,7 @@ OraclePage.propTypes = {
   txReturn: PropTypes.object,
   syncBlockTime: PropTypes.number,
   walletAddresses: PropTypes.array.isRequired,
-  selectedWalletAddress: PropTypes.string.isRequired,
+  lastUsedAddress: PropTypes.string.isRequired,
   selectWalletAddress: PropTypes.func.isRequired,
   // eslint-disable-next-line react/no-typos
   intl: intlShape.isRequired,
@@ -488,7 +488,7 @@ OraclePage.defaultProps = {
 
 const mapStateToProps = (state) => ({
   walletAddresses: state.App.get('walletAddresses'),
-  selectedWalletAddress: state.App.get('selectedWalletAddress'),
+  lastUsedAddress: state.App.get('lastUsedAddress'),
   syncBlockTime: state.App.get('syncBlockTime'),
   getOraclesReturn: state.Graphql.get('getOraclesReturn'),
   getTransactionsReturn: state.Graphql.get('getTransactionsReturn'),

--- a/src/scenes/Event/scenes/oracle.js
+++ b/src/scenes/Event/scenes/oracle.js
@@ -192,7 +192,7 @@ class OraclePage extends React.Component {
   }
 
   handleWalletChange(address) {
-    this.props.selectWalletAddress(address);
+    this.props.setLastUsedAddress(address);
   }
 
   handleConfirmClick() {
@@ -468,7 +468,7 @@ OraclePage.propTypes = {
   syncBlockTime: PropTypes.number,
   walletAddresses: PropTypes.array.isRequired,
   lastUsedAddress: PropTypes.string.isRequired,
-  selectWalletAddress: PropTypes.func.isRequired,
+  setLastUsedAddress: PropTypes.func.isRequired,
   // eslint-disable-next-line react/no-typos
   intl: intlShape.isRequired,
 };
@@ -514,7 +514,7 @@ function mapDispatchToProps(dispatch) {
       dispatch(graphqlActions.createVoteTx(version, topicAddress, oracleAddress, resultIndex, botAmount, senderAddress)),
     createFinalizeResultTx: (version, topicAddress, oracleAddress, senderAddress) =>
       dispatch(graphqlActions.createFinalizeResultTx(version, topicAddress, oracleAddress, senderAddress)),
-    selectWalletAddress: (address) => dispatch(appActions.selectWalletAddress(address)),
+    setLastUsedAddress: (address) => dispatch(appActions.setLastUsedAddress(address)),
   };
 }
 

--- a/src/scenes/Event/scenes/topic.js
+++ b/src/scenes/Event/scenes/topic.js
@@ -20,6 +20,7 @@ import EventTxHistory from '../components/EventTxHistory/index';
 import TransactionSentDialog from '../../../components/TransactionSentDialog/index';
 import topicActions from '../../../redux/Topic/actions';
 import graphqlActions from '../../../redux/Graphql/actions';
+import appActions from '../../../redux/App/actions';
 import { Token, OracleStatus } from '../../../constants';
 import CardInfoUtil from '../../../helpers/cardInfoUtil';
 

--- a/src/scenes/Event/scenes/topic.js
+++ b/src/scenes/Event/scenes/topic.js
@@ -154,7 +154,7 @@ class TopicPage extends React.Component {
     const {
       classes,
       txReturn,
-      walletAddrs,
+      walletAddresses,
       botWinnings,
       qtumWinnings,
     } = this.props;
@@ -238,7 +238,7 @@ class TopicPage extends React.Component {
               id: 'address',
             }}
           >
-            {walletAddrs.map((item, index) => (
+            {walletAddresses.map((item, index) => (
               <option key={item.address} value={index}>{item.address}</option>
             ))}
           </Select>
@@ -365,7 +365,7 @@ class TopicPage extends React.Component {
   }
 
   calculateWinnings() {
-    if (this.props.walletAddrs.length) {
+    if (this.props.walletAddresses.length) {
       this.props.calculateWinnings(
         this.state.address,
         this.getSelectedAddress()
@@ -379,7 +379,7 @@ class TopicPage extends React.Component {
   }
 
   getSelectedAddress() {
-    return this.props.walletAddrs[this.state.currentWalletIdx].address;
+    return this.props.walletAddresses[this.state.currentWalletIdx].address;
   }
 
   onWithdrawClicked() {
@@ -402,7 +402,7 @@ TopicPage.propTypes = {
   createWithdrawTx: PropTypes.func.isRequired,
   match: PropTypes.object.isRequired,
   syncBlockTime: PropTypes.number,
-  walletAddrs: PropTypes.array,
+  walletAddresses: PropTypes.array,
   walletAddrsIndex: PropTypes.number,
   calculateWinnings: PropTypes.func,
   botWinnings: PropTypes.number,
@@ -419,7 +419,7 @@ TopicPage.defaultProps = {
   getTransactions: undefined,
   getTransactionsReturn: [],
   syncBlockTime: undefined,
-  walletAddrs: [],
+  walletAddresses: [],
   walletAddrsIndex: 0,
   clearTxReturn: undefined,
   calculateWinnings: undefined,
@@ -430,7 +430,7 @@ TopicPage.defaultProps = {
 
 const mapStateToProps = (state) => ({
   syncBlockTime: state.App.get('syncBlockTime'),
-  walletAddrs: state.App.get('walletAddrs'),
+  walletAddresses: state.App.get('walletAddresses'),
   walletAddrsIndex: state.App.get('walletAddrsIndex'),
   getTopicsReturn: state.Graphql.get('getTopicsReturn'),
   getTransactionsReturn: state.Graphql.get('getTransactionsReturn'),

--- a/src/scenes/Event/scenes/topic.js
+++ b/src/scenes/Event/scenes/topic.js
@@ -375,7 +375,7 @@ class TopicPage extends React.Component {
   }
 
   handleWalletChange(address) {
-    this.props.selectWalletAddress(address);
+    this.props.setLastUsedAddress(address);
   }
 
   onWithdrawClicked() {
@@ -401,7 +401,7 @@ TopicPage.propTypes = {
   syncBlockTime: PropTypes.number,
   walletAddresses: PropTypes.array.isRequired,
   lastUsedAddress: PropTypes.string.isRequired,
-  selectWalletAddress: PropTypes.func.isRequired,
+  setLastUsedAddress: PropTypes.func.isRequired,
   calculateWinnings: PropTypes.func,
   botWinnings: PropTypes.number,
   qtumWinnings: PropTypes.number,
@@ -444,7 +444,7 @@ function mapDispatchToProps(dispatch) {
     createWithdrawTx: (version, topicAddress, senderAddress) =>
       dispatch(graphqlActions.createWithdrawTx(version, topicAddress, senderAddress)),
     clearTxReturn: () => dispatch(graphqlActions.clearTxReturn()),
-    selectWalletAddress: (address) => dispatch(appActions.selectWalletAddress(address)),
+    setLastUsedAddress: (address) => dispatch(appActions.setLastUsedAddress(address)),
   };
 }
 

--- a/src/scenes/Event/scenes/topic.js
+++ b/src/scenes/Event/scenes/topic.js
@@ -96,12 +96,12 @@ class TopicPage extends React.Component {
       botWinnings,
       qtumWinnings,
       syncBlockTime,
-      selectedWalletAddress,
+      lastUsedAddress,
     } = nextProps;
 
 
     // Update page on new block
-    if (syncBlockTime !== this.props.syncBlockTime || selectedWalletAddress !== this.props.selectedWalletAddress) {
+    if (syncBlockTime !== this.props.syncBlockTime || lastUsedAddress !== this.props.lastUsedAddress) {
       this.executeTopicAndTxsRequest();
       this.calculateWinnings();
     }
@@ -366,11 +366,11 @@ class TopicPage extends React.Component {
   }
 
   calculateWinnings() {
-    const { calculateWinnings, selectedWalletAddress } = this.props;
+    const { calculateWinnings, lastUsedAddress } = this.props;
 
     calculateWinnings(
       this.state.address,
-      selectedWalletAddress,
+      lastUsedAddress,
     );
   }
 
@@ -379,13 +379,13 @@ class TopicPage extends React.Component {
   }
 
   onWithdrawClicked() {
-    const { createWithdrawTx, selectedWalletAddress } = this.props;
+    const { createWithdrawTx, lastUsedAddress } = this.props;
     const { topic } = this.state;
 
     createWithdrawTx(
       topic.version,
       topic.address,
-      selectedWalletAddress,
+      lastUsedAddress,
     );
   }
 }
@@ -400,7 +400,7 @@ TopicPage.propTypes = {
   match: PropTypes.object.isRequired,
   syncBlockTime: PropTypes.number,
   walletAddresses: PropTypes.array.isRequired,
-  selectedWalletAddress: PropTypes.string.isRequired,
+  lastUsedAddress: PropTypes.string.isRequired,
   selectWalletAddress: PropTypes.func.isRequired,
   calculateWinnings: PropTypes.func,
   botWinnings: PropTypes.number,
@@ -427,7 +427,7 @@ TopicPage.defaultProps = {
 const mapStateToProps = (state) => ({
   syncBlockTime: state.App.get('syncBlockTime'),
   walletAddresses: state.App.get('walletAddresses'),
-  selectedWalletAddress: state.App.get('selectedWalletAddress'),
+  lastUsedAddress: state.App.get('lastUsedAddress'),
   getTopicsReturn: state.Graphql.get('getTopicsReturn'),
   getTransactionsReturn: state.Graphql.get('getTransactionsReturn'),
   txReturn: state.Graphql.get('txReturn'),

--- a/src/scenes/Wallet/components/Balances/index.jsx
+++ b/src/scenes/Wallet/components/Balances/index.jsx
@@ -52,7 +52,7 @@ class MyBalances extends React.PureComponent {
   }
 
   render() {
-    const { classes, walletAddrs } = this.props;
+    const { classes, walletAddresses } = this.props;
     const {
       selectedAddress,
       selectedAddressQtum,
@@ -67,10 +67,10 @@ class MyBalances extends React.PureComponent {
           <Typography variant="title" className={classes.myBalanceTitle}>
             <FormattedMessage id="myBalances.myBalance" defaultMessage="My Balance" />
           </Typography>
-          {this.getTotalsGrid(walletAddrs)}
+          {this.getTotalsGrid(walletAddresses)}
           <Table>
             {this.getTableHeader()}
-            {this.getTableBody(walletAddrs)}
+            {this.getTableBody(walletAddresses)}
           </Table>
           {this.getAddrCopiedSnackBar()}
           <DepositDialog
@@ -236,9 +236,9 @@ class MyBalances extends React.PureComponent {
     }
 
     if (order === 'desc') {
-      this.props.walletAddrs.sort((a, b) => (b[orderBy] < a[orderBy] ? -1 : 1));
+      this.props.walletAddresses.sort((a, b) => (b[orderBy] < a[orderBy] ? -1 : 1));
     } else {
-      this.props.walletAddrs.sort((a, b) => (a[orderBy] < b[orderBy] ? -1 : 1));
+      this.props.walletAddresses.sort((a, b) => (a[orderBy] < b[orderBy] ? -1 : 1));
     }
 
     this.setState({
@@ -384,15 +384,15 @@ class MyBalances extends React.PureComponent {
 
 MyBalances.propTypes = {
   classes: PropTypes.object.isRequired,
-  walletAddrs: PropTypes.array,
+  walletAddresses: PropTypes.array,
 };
 
 MyBalances.defaultProps = {
-  walletAddrs: [],
+  walletAddresses: [],
 };
 
 const mapStateToProps = (state) => ({
-  walletAddrs: state.App.get('walletAddrs'),
+  walletAddresses: state.App.get('walletAddresses'),
 });
 
 function mapDispatchToProps(dispatch) {

--- a/src/scenes/Wallet/components/Balances/index.jsx
+++ b/src/scenes/Wallet/components/Balances/index.jsx
@@ -52,7 +52,7 @@ class MyBalances extends React.PureComponent {
   }
 
   render() {
-    const { classes, walletAddresses } = this.props;
+    const { classes } = this.props;
     const {
       selectedAddress,
       selectedAddressQtum,
@@ -67,10 +67,10 @@ class MyBalances extends React.PureComponent {
           <Typography variant="title" className={classes.myBalanceTitle}>
             <FormattedMessage id="myBalances.myBalance" defaultMessage="My Balance" />
           </Typography>
-          {this.getTotalsGrid(walletAddresses)}
+          {this.getTotalsGrid()}
           <Table>
             {this.getTableHeader()}
-            {this.getTableBody(walletAddresses)}
+            {this.getTableBody()}
           </Table>
           {this.getAddrCopiedSnackBar()}
           <DepositDialog
@@ -94,11 +94,15 @@ class MyBalances extends React.PureComponent {
     );
   }
 
-  getTotalsGrid(data) {
-    const { classes } = this.props;
+  getTotalsGrid() {
+    const { classes, walletAddresses } = this.props;
 
-    const totalQtum = _.sumBy(data, (address) => address.qtum ? address.qtum : 0);
-    const totalBot = _.sumBy(data, (address) => address.bot ? address.bot : 0);
+    let totalQtum = 0;
+    let totalBot = 0;
+    if (walletAddresses && walletAddresses.length) {
+      totalQtum = _.sumBy(walletAddresses, (address) => address.qtum ? address.qtum : 0);
+      totalBot = _.sumBy(walletAddresses, (address) => address.bot ? address.bot : 0);
+    }
 
     const items = [
       {
@@ -247,12 +251,12 @@ class MyBalances extends React.PureComponent {
     });
   }
 
-  getTableBody(data) {
-    const { classes } = this.props;
+  getTableBody() {
+    const { classes, walletAddresses } = this.props;
 
     return (
       <TableBody>
-        {data.map((item, index) =>
+        {walletAddresses.map((item, index) =>
           (<TableRow key={item.address} selected={index % 2 !== 0}>
             <TableCell>
               <Typography variant="body1">{item.address}</Typography>
@@ -384,11 +388,7 @@ class MyBalances extends React.PureComponent {
 
 MyBalances.propTypes = {
   classes: PropTypes.object.isRequired,
-  walletAddresses: PropTypes.array,
-};
-
-MyBalances.defaultProps = {
-  walletAddresses: [],
+  walletAddresses: PropTypes.array.isRequired,
 };
 
 const mapStateToProps = (state) => ({


### PR DESCRIPTION
- Fixed all bugs with qtum and bot balances.
- Addresses are now a cumulative list. ie. if you had 1 address from 1 unspent, and you spent that output, that address might disappear since you get a new unspent output address (only from sendtoaddress). Now if you address changes, it will just add to the list of addresses that is being cached. This helps so people wont get freaked out about disappearing addresses.
- Removed old way of storing the selected wallet address by index

![image](https://user-images.githubusercontent.com/4350404/37239688-c6c9a92c-2472-11e8-9835-2628e42a36bf.png)
