### PR TITLE
Finalize amount

### DIFF
--- a/src/components/EventCard/index.js
+++ b/src/components/EventCard/index.js
@@ -75,11 +75,14 @@ class EventCard extends React.PureComponent {
                 }
               </div>
               <div className={classes.eventCardInfo}>
-                <div>
-                  <i className={classNames(classes.dashBoardCardIcon, 'icon', 'iconfont', 'icon-ic_token')}></i>
-                  <FormattedMessage id="str.raised" defaultMessage="Raised" />
-                  {` ${amountLabel}`}
-                </div>
+                {
+                  amountLabel &&
+                  <div>
+                    <i className={classNames(classes.dashBoardCardIcon, 'icon', 'iconfont', 'icon-ic_token')}></i>
+                    <FormattedMessage id="str.raised" defaultMessage="Raised" />
+                    {` ${amountLabel}`}
+                  </div>
+                }
                 <div>
                   <i className={classNames(classes.dashBoardCardIcon, 'icon', 'iconfont', 'icon-ic_timer')}></i>
                   {endTime !== undefined

--- a/src/components/EventCardsGridContainer/index.js
+++ b/src/components/EventCardsGridContainer/index.js
@@ -267,21 +267,18 @@ class EventCardsGrid extends React.Component {
     _.each(oracles, (oracle) => {
       const amount = parseFloat(_.sum(oracle.amounts).toFixed(2));
       let buttonText;
-      let amountLabel;
+      let amountLabel = `${amount} ${oracle.token}`;
       switch (eventStatusIndex) {
         case EventStatus.Bet: {
           buttonText = this.props.intl.formatMessage(messages.placeBet);
-          amountLabel = `${amount} ${oracle.token}`;
           break;
         }
         case EventStatus.Set: {
           buttonText = this.props.intl.formatMessage(messages.setResult);
-          amountLabel = `${amount} ${oracle.token}`;
           break;
         }
         case EventStatus.Vote: {
           buttonText = this.props.intl.formatMessage(messages.vote);
-          amountLabel = `${amount} ${oracle.token}`;
           break;
         }
         case EventStatus.Finalize: {

--- a/src/components/EventCardsGridContainer/index.js
+++ b/src/components/EventCardsGridContainer/index.js
@@ -265,30 +265,34 @@ class EventCardsGrid extends React.Component {
   renderOracles(oracles, eventStatusIndex) {
     const rowItems = [];
     _.each(oracles, (oracle) => {
+      const amount = parseFloat(_.sum(oracle.amounts).toFixed(2));
       let buttonText;
+      let amountLabel;
       switch (eventStatusIndex) {
         case EventStatus.Bet: {
           buttonText = this.props.intl.formatMessage(messages.placeBet);
+          amountLabel = `${amount} ${oracle.token}`;
           break;
         }
         case EventStatus.Set: {
           buttonText = this.props.intl.formatMessage(messages.setResult);
+          amountLabel = `${amount} ${oracle.token}`;
           break;
         }
         case EventStatus.Vote: {
           buttonText = this.props.intl.formatMessage(messages.vote);
+          amountLabel = `${amount} ${oracle.token}`;
           break;
         }
         case EventStatus.Finalize: {
           buttonText = this.props.intl.formatMessage(messages.finalizeResult);
+          amountLabel = undefined;
           break;
         }
         default: {
           throw new RangeError(`Invalid tab position ${eventStatusIndex}`);
         }
       }
-
-      const amount = parseFloat(_.sum(oracle.amounts).toFixed(2));
 
       // Constructing Card element on the right
       const oracleEle = (
@@ -297,7 +301,7 @@ class EventCardsGrid extends React.Component {
           name={oracle.name}
           url={`/oracle/${oracle.topicAddress}/${oracle.address}/${oracle.txid}`}
           endTime={eventStatusIndex === EventStatus.Set ? oracle.resultSetEndTime : oracle.endTime}
-          amountLabel={`${amount} ${oracle.token}`}
+          amountLabel={amountLabel}
           buttonText={buttonText}
           unconfirmed={!oracle.topicAddress && !oracle.address}
         />


### PR DESCRIPTION
#432 
Issue was that the amount did not reflect how much QTUM/BOT was raised in all the rounds. With current BE scheme, we would have to do many hacky calls just to get the total amounts.

Removed `Raised` label for `Finalize` cards. Showing this info is inconsequential for this stage since it doesn't matter how much was raised during this Oracle since it didn't hit the threshold.

![image](https://user-images.githubusercontent.com/4350404/38070103-4d18d518-3344-11e8-8d39-72c00717cf4a.png)
