### PR TITLE
Finalize mutation

### DIFF
--- a/src/network/graphMutation.js
+++ b/src/network/graphMutation.js
@@ -118,11 +118,12 @@ export function createVoteTx(version, topicAddress, oracleAddress, optionIdx, am
   return new GraphMutation('createVote', args, TYPE.transaction).execute();
 }
 
-export function createFinalizeResultTx(version, topicAddress, oracleAddress, senderAddress) {
+export function createFinalizeResultTx(version, topicAddress, oracleAddress, optionIdx, senderAddress) {
   const args = {
     version,
     topicAddress,
     oracleAddress,
+    optionIdx,
     senderAddress,
   };
 

--- a/src/network/graphSchema.js
+++ b/src/network/graphSchema.js
@@ -210,6 +210,7 @@ const MUTATIONS = {
       'version',
       'topicAddress',
       'oracleAddress',
+      'optionIdx',
       'senderAddress',
     ],
     return: `
@@ -219,6 +220,7 @@ const MUTATIONS = {
       type
       status
       oracleAddress
+      optionIdx
       senderAddress
     `,
   },

--- a/src/redux/Graphql/actions.js
+++ b/src/redux/Graphql/actions.js
@@ -120,12 +120,13 @@ const graphqlActions = {
 
   CREATE_FINALIZE_RESULT_TX: 'CREATE_FINALIZE_RESULT_TX',
   CREATE_FINALIZE_RESULT_TX_RETURN: 'CREATE_FINALIZE_RESULT_TX_RETURN',
-  createFinalizeResultTx: (version, topicAddress, oracleAddress, senderAddress) => ({
+  createFinalizeResultTx: (version, topicAddress, oracleAddress, optionIdx, senderAddress) => ({
     type: graphqlActions.CREATE_FINALIZE_RESULT_TX,
     params: {
       version,
       topicAddress,
       oracleAddress,
+      optionIdx,
       senderAddress,
     },
   }),

--- a/src/redux/Graphql/saga.js
+++ b/src/redux/Graphql/saga.js
@@ -421,6 +421,7 @@ export function* createFinalizeResultTxHandler() {
         action.params.version,
         action.params.topicAddress,
         action.params.oracleAddress,
+        action.params.optionIdx,
         action.params.senderAddress,
       );
 

--- a/src/scenes/Event/scenes/oracle.js
+++ b/src/scenes/Event/scenes/oracle.js
@@ -94,8 +94,8 @@ const messages = defineMessages({
     )),
   createVoteTx: (version, topicAddress, oracleAddress, resultIndex, botAmount, senderAddress) =>
     dispatch(graphqlActions.createVoteTx(version, topicAddress, oracleAddress, resultIndex, botAmount, senderAddress)),
-  createFinalizeResultTx: (version, topicAddress, oracleAddress, senderAddress) =>
-    dispatch(graphqlActions.createFinalizeResultTx(version, topicAddress, oracleAddress, senderAddress)),
+  createFinalizeResultTx: (version, topicAddress, oracleAddress, optionIdx, senderAddress) =>
+    dispatch(graphqlActions.createFinalizeResultTx(version, topicAddress, oracleAddress, optionIdx, senderAddress)),
   setLastUsedAddress: (address) => dispatch(appActions.setLastUsedAddress(address)),
 }))
 export default class OraclePage extends React.Component {
@@ -765,6 +765,14 @@ export default class OraclePage extends React.Component {
     const { createFinalizeResultTx, lastUsedAddress } = this.props;
     const { oracle } = this.state;
 
-    createFinalizeResultTx(oracle.version, oracle.topicAddress, oracle.address, lastUsedAddress);
+    let winningOptionIdx;
+    for (let i = 0; i < oracle.options.length; i++) {
+      if (!_.includes(oracle.optionIdxs, i)) {
+        winningOptionIdx = i;
+        break;
+      }
+    }
+
+    createFinalizeResultTx(oracle.version, oracle.topicAddress, oracle.address, winningOptionIdx, lastUsedAddress);
   }
 }


### PR DESCRIPTION
Pass optionIdx to finalize result mutation so we can see it in the tx history.

![image](https://user-images.githubusercontent.com/4350404/38080971-0eb52898-336d-11e8-8d25-abfcf8100412.png)

Depends on: https://github.com/bodhiproject/bodhi-graphql/pull/172