### PR TITLE
Change wallet unlocked text

### DIFF
--- a/src/languageProvider/locales/en_US.json
+++ b/src/languageProvider/locales/en_US.json
@@ -279,7 +279,7 @@
   "walletUnlockDialog.unlockWallet": "Unlock Wallet",
   "walletUnlockDialog.walletPassphrase": "Wallet Passphrase",
   "walletUnlockDialog.walletPassphraseRequired": "This action requires you to unlock this wallet. Please enter your wallet passphrase.",
-  "walletUnlockDialog.walletUnlocked": "Wallet unlocked! Please redo your action.",
+  "walletUnlockDialog.walletUnlocked": "Wallet unlocked!",
   "withdrawDetail.alreadyWithdrawn": "You have already withdrawn with this address.",
   "withdrawDetail.returnRate": "Return rate:",
   "withdrawDetail.reward": "REWARD",

--- a/src/languageProvider/locales/zh-Hans.json
+++ b/src/languageProvider/locales/zh-Hans.json
@@ -281,7 +281,7 @@
   "walletUnlockDialog.unlockWallet": "解锁钱包",
   "walletUnlockDialog.walletPassphrase": "钱包密码",
   "walletUnlockDialog.walletPassphraseRequired": "这个操作需要解锁您的钱包，请输入您的密码.",
-  "walletUnlockDialog.walletUnlocked": "钱包已解锁！请重新进行您的操作。",
+  "walletUnlockDialog.walletUnlocked": "钱包已解锁！",
   "withdrawDetail.alreadyWithdrawn": "您已经使用过此地址提现。",
   "withdrawDetail.returnRate": "回报率：",
   "withdrawDetail.reward": "回报",

--- a/src/scenes/App/globalHub.js
+++ b/src/scenes/App/globalHub.js
@@ -16,7 +16,7 @@ let syncInfoInterval;
 const messages = defineMessages({
   walletUnlocked: {
     id: 'walletUnlockDialog.walletUnlocked',
-    defaultMessage: 'Wallet unlocked! Please redo your action.',
+    defaultMessage: 'Wallet unlocked!',
   },
 });
 


### PR DESCRIPTION
Changed the wallet unlock text to something more generic since it will pop up when you start the app.

![image](https://user-images.githubusercontent.com/4350404/40837751-b441ec1c-65c5-11e8-8d57-ea1b660f77e6.png)
