### PR TITLE
Upgrade react-dom

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13403,14 +13403,14 @@
       }
     },
     "react-dom": {
-      "version": "15.6.2",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.6.2.tgz",
-      "integrity": "sha1-Qc+t9pO3V/rycIRDodH9WgK+9zA=",
+      "version": "16.4.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.4.1.tgz",
+      "integrity": "sha512-1Gin+wghF/7gl4Cqcvr1DxFX2Osz7ugxSwl6gBqCMpdrxHjIFUS7GYxrFftZ9Ln44FHw0JxCFD9YtZsrbR5/4A==",
       "requires": {
-        "fbjs": "^0.8.9",
+        "fbjs": "^0.8.16",
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.0",
-        "prop-types": "^15.5.10"
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.0"
       }
     },
     "react-drawer": {
@@ -13771,6 +13771,17 @@
           "integrity": "sha1-26BDSrQ5z+gvEI8PURZjkIF5qnI=",
           "requires": {
             "create-react-class": "^15.6.0",
+            "fbjs": "^0.8.9",
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.0",
+            "prop-types": "^15.5.10"
+          }
+        },
+        "react-dom": {
+          "version": "15.6.2",
+          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.6.2.tgz",
+          "integrity": "sha1-Qc+t9pO3V/rycIRDodH9WgK+9zA=",
+          "requires": {
             "fbjs": "^0.8.9",
             "loose-envify": "^1.1.0",
             "object-assign": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "react-apollo": "^2.0.4",
     "react-copy-to-clipboard": "^5.0.1",
     "react-custom-scrollbars": "^4.1.2",
-    "react-dom": "^15.5.4",
+    "react-dom": "^16.4.1",
     "react-drawer": "^1.2.5",
     "react-element-resize": "^0.2.1",
     "react-flip-move": "^2.9.2",

--- a/src/components/BottomBar/index.js
+++ b/src/components/BottomBar/index.js
@@ -70,9 +70,9 @@ const NetworkConnection = withStyles(styles)(({ classes }) => (
   <Grid item xs={12} md={6} className={classes.bottomBarNetworkWrapper}>
     <Typography variant="body1">
       {navigator.onLine ? (
-        <CheckCircleIcon fontSize className={cx(classes.bottomBarNetworkIcon, 'online')} />
+        <CheckCircleIcon className={cx(classes.bottomBarNetworkIcon, 'online')} />
       ) : (
-        <RemoveCircleIcon fontSize className={cx(classes.bottomBarNetworkIcon, 'offline')} />
+        <RemoveCircleIcon className={cx(classes.bottomBarNetworkIcon, 'offline')} />
       )}
       <span>
         {navigator.onLine ? (

--- a/src/components/EventsEmptyBg/index.js
+++ b/src/components/EventsEmptyBg/index.js
@@ -10,7 +10,7 @@ import styles from './styles';
 
 const EventsEmptyBg = ({ classes }) => (
   <div className={classes.eventsEmptyWrapper}>
-    <EventIcon className={classes.eventsEmptyIcon} fontSize />
+    <EventIcon className={classes.eventsEmptyIcon} />
     <Typography variant="body1"><FormattedMessage id="dashboard.empty" defaultMessage="No Event at Current Status" /> </Typography>
   </div>
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -7345,7 +7345,7 @@ react-dock@^0.2.4:
     lodash.debounce "^3.1.1"
     prop-types "^15.5.8"
 
-react-dom@>=0.14.0:
+react-dom@>=0.14.0, react-dom@^16.4.1:
   version "16.4.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.4.1.tgz#7f8b0223b3a5fbe205116c56deb85de32685dad6"
   dependencies:
@@ -7354,7 +7354,7 @@ react-dom@>=0.14.0:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
-react-dom@^15.0.2, react-dom@^15.5.4:
+react-dom@^15.0.2:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.6.2.tgz#41cfadf693b757faf2708443a1d1fd5a02bef730"
   dependencies:
@@ -7573,7 +7573,7 @@ react-window-resize-listener@^1.1.0:
   dependencies:
     lodash.debounce "^3.1.1"
 
-react@>=0.14.0:
+react@>=0.14.0, react@^16.4.1:
   version "16.4.1"
   resolved "https://registry.yarnpkg.com/react/-/react-16.4.1.tgz#de51ba5764b5dbcd1f9079037b862bd26b82fe32"
   dependencies:


### PR DESCRIPTION
should have done this with #631 

but I just noticed the @material-ui/core required react-dom v16 as well

no breaking, upgrade smoothly